### PR TITLE
Two test failures that were the environment, not the code

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 SQLite Cloud, Inc.
+#
+# This file exists to make `tests` a regular package, and that is its whole
+# job. Without it the directory is only an implicit namespace portion, and
+# the import system prefers a *regular* package found later on sys.path —
+# so any unrelated `tests` package installed in site-packages shadows this
+# one and `python3 -m unittest discover -s tests/serve -t .` fails to
+# import tests.serve at all. That is not a hypothetical: it happened, and
+# the whole serve suite reported as one failure with no hint that the
+# module it could not find was ours.

--- a/tests/range_server.py
+++ b/tests/range_server.py
@@ -21,7 +21,27 @@ taken". --port-file is how the caller learns which port it got.
 import http.server
 import os
 import re
+import socketserver
 import sys
+
+
+class Server(http.server.HTTPServer):
+    """HTTPServer without the reverse DNS lookup in its constructor.
+
+    HTTPServer.server_bind calls socket.getfqdn() on the address it just
+    bound, and TCPServer.__init__ runs it *between* bind() and the listen()
+    in server_activate. For 127.0.0.1 the answer is worth nothing — nothing
+    here reads server_name — but on a macOS CI runner it blocked for about
+    fifteen seconds, and until it returns the port is bound and not yet
+    listening, so a caller connecting in that window is refused rather than
+    queued. It also delayed the port file below past the caller's patience:
+    the first server of a run failed to report in time, the second was fast
+    because the resolver had cached the answer by then.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
 
 
 def make_handler(root, ranges):
@@ -75,7 +95,7 @@ def main():
         del argv[i:i + 2]
     ranges = "--no-range" not in argv
     root, port = [a for a in argv if not a.startswith("--")][:2]
-    srv = http.server.HTTPServer(("127.0.0.1", int(port)), make_handler(root, ranges))
+    srv = Server(("127.0.0.1", int(port)), make_handler(root, ranges))
 
     # Hand the real port back only after the constructor has bound and
     # listened, so a caller that sees this file can connect immediately —

--- a/tests/range_server.py
+++ b/tests/range_server.py
@@ -10,7 +10,12 @@ not silently accept. This serves a directory with real 206 responses, or
 with Range support switched off, so both branches of the worker's resume
 logic can be exercised without touching the network.
 
-  python3 tests/range_server.py DIR PORT [--no-range]
+  python3 tests/range_server.py DIR PORT [--no-range] [--port-file F]
+
+PORT 0 asks the kernel for a free one, which is what the caller should
+use: a hardcoded port is a check that fails on any machine already running
+something there, and it fails as "resume" rather than as "that port is
+taken". --port-file is how the caller learns which port it got.
 """
 
 import http.server
@@ -62,9 +67,26 @@ def make_handler(root, ranges):
 
 
 def main():
-    root, port = sys.argv[1], int(sys.argv[2])
-    ranges = "--no-range" not in sys.argv
-    srv = http.server.HTTPServer(("127.0.0.1", port), make_handler(root, ranges))
+    argv = sys.argv[1:]
+    port_file = None
+    if "--port-file" in argv:
+        i = argv.index("--port-file")
+        port_file = argv[i + 1]
+        del argv[i:i + 2]
+    ranges = "--no-range" not in argv
+    root, port = [a for a in argv if not a.startswith("--")][:2]
+    srv = http.server.HTTPServer(("127.0.0.1", int(port)), make_handler(root, ranges))
+
+    # Hand the real port back only after the constructor has bound and
+    # listened, so a caller that sees this file can connect immediately —
+    # anything arriving before serve_forever() waits in the backlog rather
+    # than being refused. Written under a temp name and renamed, so a
+    # caller polling for the file never reads half a number.
+    if port_file:
+        with open(port_file + ".tmp", "w") as f:
+            f.write(str(srv.server_address[1]))
+        os.replace(port_file + ".tmp", port_file)
+
     srv.serve_forever()
 
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -92,49 +92,73 @@ fetch_worker() {                       # $1 = generated worker path
     bash "$FT/gen.sh"
 }
 
+# The port comes from the kernel, not from this file. Two fixed ones (8731,
+# 8732) cost an afternoon on a machine already running something on the
+# first: range_server.py could not bind, the worker talked to whatever else
+# was listening, and the failure surfaced as "resume" and "state-file skip"
+# — two checks blaming the code under test for the environment. Nothing
+# here needs a *particular* port, only a free one, so ask for one and read
+# back what was given. The `sleep 1` this replaces was the other half of
+# the same bug: a fixed wait is either too long or, on a loaded machine,
+# not long enough.
+start_server() {                       # $@ = extra server args; sets PORT, RSRV
+    local pf="$FT/port"
+    rm -f "$pf" "$pf.tmp"
+    python3 tests/range_server.py "$FT/srv" 0 --port-file "$pf" "$@" \
+        >/dev/null 2>&1 &
+    RSRV=$!
+    PORT=
+    for _ in $(seq 100); do            # 10 s, in 100 ms steps
+        [ -s "$pf" ] && { PORT=$(cat "$pf"); break; }
+        kill -0 "$RSRV" 2>/dev/null || break   # it died; stop waiting
+        sleep 0.1
+    done
+    [ -n "$PORT" ]
+}
+
 FT="$TMP/fetch"
 mkdir -p "$FT/srv" "$FT/dst"
 if stat --version >/dev/null 2>&1; then SM=gnu; else SM=bsd; fi
 python3 -c "open('$FT/srv/s.bin','wb').write(bytes(range(256))*4096)"
 
-PORT=8731
-python3 tests/range_server.py "$FT/srv" $PORT >/dev/null 2>&1 &
-RSRV=$!
-sleep 1
-head -c 400000 "$FT/srv/s.bin" > "$FT/dst/s.bin"
-fetch_worker $PORT $SM
-: > "$FT/dst/.st"
-bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
-if cmp -s "$FT/srv/s.bin" "$FT/dst/s.bin" && grep -q "^s.bin$" "$FT/dst/.st"; then
-    ok "a truncated shard resumes and verifies against Content-Length"
+if ! start_server; then
+    no "range server did not start (resume, state-file skip not run)"
 else
-    no "resume"
+    head -c 400000 "$FT/srv/s.bin" > "$FT/dst/s.bin"
+    fetch_worker $PORT $SM
+    : > "$FT/dst/.st"
+    bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
+    if cmp -s "$FT/srv/s.bin" "$FT/dst/s.bin" && grep -q "^s.bin$" "$FT/dst/.st"; then
+        ok "a truncated shard resumes and verifies against Content-Length"
+    else
+        no "resume"
+    fi
+    # second pass: recorded in the state file, so not even a HEAD goes out
+    before=$(wc -l < "$FT/dst/log")
+    bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
+    if [ "$(wc -l < "$FT/dst/log")" = "$before" ]; then
+        ok "a completed shard is skipped without a request"
+    else
+        no "state-file skip"
+    fi
+    kill $RSRV 2>/dev/null; wait $RSRV 2>/dev/null
 fi
-# second pass: recorded in the state file, so not even a HEAD goes out
-before=$(wc -l < "$FT/dst/log")
-bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
-if [ "$(wc -l < "$FT/dst/log")" = "$before" ]; then
-    ok "a completed shard is skipped without a request"
-else
-    no "state-file skip"
-fi
-kill $RSRV 2>/dev/null; wait $RSRV 2>/dev/null
 
-PORT=8732
-python3 tests/range_server.py "$FT/srv" $PORT --no-range >/dev/null 2>&1 &
-RSRV=$!
-sleep 1
-rm -f "$FT/dst/s.bin" "$FT/dst/.st" "$FT/dst/log"
-head -c 400000 "$FT/srv/s.bin" > "$FT/dst/s.bin"
-fetch_worker $PORT $SM
-: > "$FT/dst/.st"
-bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
-if cmp -s "$FT/srv/s.bin" "$FT/dst/s.bin"; then
-    ok "a server without Range support restarts the shard instead of giving up"
+if ! start_server --no-range; then
+    no "range server did not start (no-range fallback not run)"
 else
-    no "no-range fallback"
+    rm -f "$FT/dst/s.bin" "$FT/dst/.st" "$FT/dst/log"
+    head -c 400000 "$FT/srv/s.bin" > "$FT/dst/s.bin"
+    fetch_worker $PORT $SM
+    : > "$FT/dst/.st"
+    bash "$FT/dst/.worker.sh" s.bin >/dev/null 2>&1
+    if cmp -s "$FT/srv/s.bin" "$FT/dst/s.bin"; then
+        ok "a server without Range support restarts the shard instead of giving up"
+    else
+        no "no-range fallback"
+    fi
+    kill $RSRV 2>/dev/null; wait $RSRV 2>/dev/null
 fi
-kill $RSRV 2>/dev/null; wait $RSRV 2>/dev/null
 
 # ---------------------------------------------------------------- image ----
 head_ "image"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -113,6 +113,10 @@ start_server() {                       # $@ = extra server args; sets PORT, RSRV
         kill -0 "$RSRV" 2>/dev/null || break   # it died; stop waiting
         sleep 0.1
     done
+    # A server that never reported is still a process, and the caller below
+    # only kills the ones it was told about — CI reported exactly one
+    # orphaned Python the first time this path fired.
+    [ -n "$PORT" ] || { kill "$RSRV" 2>/dev/null; wait "$RSRV" 2>/dev/null; }
     [ -n "$PORT" ]
 }
 


### PR DESCRIPTION
[![CI](https://github.com/sqliteai/waste/actions/workflows/ci.yml/badge.svg)](https://github.com/sqliteai/waste/actions/workflows/ci.yml)
<sub>status of upstream `main` — this PR's own run is still awaiting maintainer approval, as fork PRs do not start workflows on their own.</sub>

Three checks in `tests/run.sh` fail on any machine whose environment happens to differ from the author's, and both causes blame the code under test.

## The port the suite hardcoded

`tests/run.sh` used fixed ports 8731 and 8732 for the range server the download worker talks to. On a machine already running something on 8731, `range_server.py` cannot bind, the worker resumes against whatever else answers, and the failure surfaces as **"resume"** and **"state-file skip"** — two checks pointing at `tools/fetch_weights.sh`, which is fine. The third check passes only because 8732 happens to be free.

Nothing there needs a *particular* port, only a free one. `range_server.py` now takes port `0` and reports back what the kernel gave it through `--port-file`, written under a temp name and renamed so a caller polling for the file cannot read half a number. It is written after the constructor has bound and listened and before `serve_forever`, so a caller that sees the file can connect immediately — anything arriving early waits in the backlog rather than being refused.

That also removes the `sleep 1` before each server, which was the same bug from the other side: a fixed wait is either longer than it needs to be or, on a loaded machine, not long enough. `start_server` polls in 100 ms steps and stops early if the process died. When it cannot start one, the block says so and names the checks that did not run, instead of letting them fail as though they had.

## The package that shadowed `tests/`

The serve suite failed for an unrelated reason with the same shape: an unrelated `tests` package installed in site-packages shadows this directory, so `python3 -m unittest discover -s tests/serve -t .` cannot import `tests.serve` and reports the whole suite as one failure naming nothing.

`tests/` had no `__init__.py`, which makes it an implicit namespace portion, and the import system prefers a *regular* package found later on `sys.path` over an earlier portion. `tests/__init__.py` exists to lose that race deliberately, and says so in a comment so it does not read as an accident someone can delete.

## Verification

**24 passed, 0 failed, 11 skipped** in `tests/run.sh` on a clone with no container — the three failures above were the whole difference — and **167/167** in the serve suite with no `PYTHONNOUSERSITE` workaround. Verified with the conflicting daemon still holding 8731. `--no-range` confirmed still reaching the server (no `Accept-Ranges` in the response), and the CI SPDX guard still passes.

`CLAUDE.md` was split out into #2 — this PR is the test fix alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

