### PR TITLE
The best possible warm start, reported as a failure

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -456,13 +456,26 @@ PY
     if [ "$SYNTHETIC" = 1 ]; then
         sk "learned hotlist" "synthetic container carries no tokenizer"
     else
+    # Empty, not 0, when the count cannot be read: a run that printed no
+    # stat line and a run that missed nothing are different outcomes, and
+    # `|| echo 0` used to collapse them. On a machine whose budget holds the
+    # whole working set the warm run reaches 0 misses — the best result this
+    # check can produce — and the old `warm -gt 0` guard reported it as
+    # "hotlist did not reduce misses (584 -> 0)".
+    misses() { grep -oE "[0-9]+ miss" | grep -oE "[0-9]+"; }
     rm -f "$MODEL/usage.waste"
     cold=$(./waste run "$MODEL" "The capital of France is" -n 12 --budget 5G --learn 2>&1 \
-           | grep -oE "[0-9]+ miss" | grep -oE "[0-9]+" || echo 0)
+           | misses)
     warm=$(./waste run "$MODEL" "The capital of France is" -n 12 --budget 5G 2>&1 \
-           | grep -oE "[0-9]+ miss" | grep -oE "[0-9]+" || echo 0)
+           | misses)
     rm -f "$MODEL/usage.waste"
-    if [ "${warm:-0}" -gt 0 ] && [ "${warm:-0}" -lt "${cold:-0}" ]; then
+    if [ -z "$cold" ] || [ -z "$warm" ]; then
+        no "hotlist: no miss count in the output of waste run"
+    elif [ "$cold" -eq 0 ]; then
+        # Nothing to warm, so nothing is demonstrated either way. Saying
+        # PASS here would be passing by luck.
+        sk "learned hotlist" "the cold run already missed nothing"
+    elif [ "$warm" -lt "$cold" ]; then
         ok "learned hotlist warms the cache ($cold -> $warm misses)"
     else
         no "hotlist did not reduce misses ($cold -> $warm)"


### PR DESCRIPTION
The learned-hotlist check fails when the hotlist works perfectly.

## What happens

`tests/run.sh` reads a miss count out of `waste run`:

```bash
warm=$(... | grep -oE "[0-9]+ miss" | grep -oE "[0-9]+" || echo 0)
...
if [ "${warm:-0}" -gt 0 ] && [ "${warm:-0}" -lt "${cold:-0}" ]; then
```

The `warm -gt 0` guard is there for a real case — a run that printed no stat line leaves grep with nothing, and the empty string would then be compared as a number. But `|| echo 0` gives that case **the same value as a run that missed nothing**, and those are opposite outcomes.

On a machine whose 5 GB budget holds the whole working set, the second run serves every expert from RAM:

```
cold (--learn): 1912 hit /  584 miss =  77%   5.33 tok/s
warm:           2496 hit /    0 miss = 100%   8.52 tok/s
```

A 60% speedup and a perfect warm start — reported as:

```
FAIL  hotlist did not reduce misses (584 -> 0)
```

The counts are identical on 0.6.0 and 0.6.1, so it is not a flake.

## The fix

Yield empty rather than `0` when there is no count. That keeps the guard the old code wanted — an unparseable run still fails, and `[ -z ]` never compares a non-number — while letting zero misses be the success it is.

A cold run that already missed nothing becomes **SKIP**, not PASS: nothing is demonstrated in that case, and this suite is explicit about never treating a missing prerequisite as a pass.

| cold | warm | result |
|---|---|---|
| 584 | 0 | PASS |
| 584 | 12 | PASS |
| 584 | 900 | FAIL (no reduction) |
| 584 | *(no count)* | FAIL (no miss count in output) |
| 0 | 0 | SKIP (nothing to warm) |

## Verification

Against a real Kimi-Linear container (49.12 B, converted from the released shards with `tools/convert.py`), at `v0.6.1`:

```
before:  29 passed, 3 failed, 5 skipped
after:   30 passed, 2 failed, 5 skipped
         PASS  learned hotlist warms the cache (584 -> 0 misses)
```

The two remaining failures are unrelated to this change and unchanged by it (`int8 storage changes results`, `engine diverges from the oracle` — happy to write those up separately; both look like they need a maintainer's call).

**CI cannot cover this change.** It has no container, so the check skips there for want of a tokenizer — the synthetic container carries none. It was verified locally against real weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)