### PR TITLE
The trunk width the load path could not read, and the container that hid it

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -555,39 +555,7 @@ static int load_trunk(waste_model *m, const char *dir, const js_doc *d, int trun
             t->data = (float *)waste_dio_alloc(t->n * sizeof(float));
             if (!t->data) TRUNK_FAIL;
             if (pread_all(fd, t->data, t->n * sizeof(float), off)) TRUNK_FAIL;
-        } else if (!q8_off) {                             /* Q8G -> f32 */
-            const int N = t->shape[t->ndim - 1];
-            const int64_t rows = (int64_t)(t->n / (size_t)N);
-            const int ng = (N + g - 1) / g;
-            t->data = (float *)waste_dio_alloc(t->n * sizeof(float));
-            int8_t *qbuf = (int8_t *)malloc((size_t)rows * ng * g);
-            uint16_t *sbuf = (uint16_t *)malloc((size_t)rows * ng * sizeof(uint16_t));
-            if (!t->data || !qbuf || !sbuf ||
-                pread_all(fd, qbuf, (size_t)rows * ng * g, off) ||
-                pread_all(fd, sbuf, (size_t)rows * ng * sizeof(uint16_t), soff)) {
-                free(qbuf); free(sbuf); TRUNK_FAIL;
-            }
-            const int8_t *q = qbuf;
-            const uint16_t *sc = sbuf;
-            for (int64_t r = 0; r < rows; r++) {
-                for (int b = 0; b < ng; b++) {
-                    /* fp16 -> float without <arm_fp16.h> assumptions */
-                    const uint16_t h = sc[r * ng + b];
-                    const uint32_t sign = (uint32_t)(h >> 15) << 31;
-                    uint32_t exp = (h >> 10) & 0x1f, man = h & 0x3ff, bits;
-                    if (exp == 0) { bits = sign; }
-                    else { bits = sign | ((exp + 112u) << 23) | (man << 13); }
-                    float s;
-                    memcpy(&s, &bits, 4);
-                    for (int k = 0; k < g; k++) {
-                        const int col = b * g + k;
-                        if (col >= N) break;
-                        t->data[r * N + col] = (float)q[(r * ng + b) * g + k] * s;
-                    }
-                }
-            }
-            free(qbuf); free(sbuf);
-        } else {                             /* Q8G or Q4G, kept quantized */
+        } else {                             /* Q8G, Q4G or Q3G */
             const int N = t->shape[t->ndim - 1];
             const int64_t rows = (int64_t)(t->n / (size_t)N);
             const int ng = (N + g - 1) / g;
@@ -614,6 +582,39 @@ static int load_trunk(waste_model *m, const char *dir, const js_doc *d, int trun
             if (pread_all(fd, t->q, payload, off) ||
                 pread_all(fd, t->qs, (size_t)rows * ng * sizeof(uint16_t), soff))
                 TRUNK_FAIL;
+
+            /* WASTE_Q8=0 dequantizes the trunk once here instead of at every
+             * use. It runs after the quantized load and hands the rows to
+             * waste_deq_row — the same unpacker the compute path calls — so
+             * a width this code does not itself know about cannot be
+             * mis-read at load while working everywhere else.
+             *
+             * It used to be a branch of its own, ahead of this one, with a
+             * private copy of the Q8 unpacking that read `rows * ng * g`
+             * bytes: one byte per weight. That is true of Q8G alone, but the
+             * branch caught every non-F32 format, so a Q4G trunk — what
+             * `--trunk-bits 4`, the default, produces — asked for twice the
+             * bytes it occupies and the load failed outright. Only the
+             * synthetic container, whose trunk is Q8G/F32, took the one
+             * shape it handled, which is why CI never saw it.
+             *
+             * embed_tokens stays on disk above either way: its rows go
+             * through the same unpacker when read, so the logits are
+             * identical and 1.11 GB stays out of the resident set. */
+            if (!q8_off) {
+                float *f32 = (float *)waste_dio_alloc(t->n * sizeof(float));
+                if (!f32) TRUNK_FAIL;
+                for (int64_t r = 0; r < rows; r++)
+                    waste_deq_row(t, (long)r, N, f32 + (size_t)r * (size_t)N);
+                waste_dio_free(t->q);  t->q  = NULL;
+                waste_dio_free(t->qs); t->qs = NULL;
+                /* Indistinguishable from a tensor that was F32 on disk:
+                 * unpack_row_i8 and friends branch on bits without
+                 * consulting q, and m->t is calloc'd, so a real F32 tensor
+                 * carries zeroes in all three. */
+                t->bits = 0; t->rowbytes = 0; t->group = 0;
+                t->data = f32;
+            }
         }
     }
     m->trunk_fd = fd;   /* on-disk tensors read through it */

--- a/tools/make_test_container.py
+++ b/tools/make_test_container.py
@@ -33,7 +33,7 @@ import zlib
 MAGIC_EXPERT = 0x50584557        # 'WEXP'
 MAGIC_CODEBOOK = 0x4B424357      # 'WCBK'
 ALIGN = 4096
-FMT_F32, FMT_Q8G, FMT_VQ3R = 0, 2, 4
+FMT_F32, FMT_Q8G, FMT_Q4G, FMT_VQ3R = 0, 2, 3, 4
 VEC_DIM, CB_ENTRIES, STAGES, IDX_BLOCK = 8, 256, 3, 64
 GROUP = 128
 KINDS = ("gate", "up", "down")
@@ -93,7 +93,15 @@ def f16(vals):
 
 class Trunk:
     """Accumulates trunk.bin and its index, in the layout model.c reads:
-    F32 verbatim, Q8G as int8 rows followed by one fp16 scale per group."""
+    F32 verbatim, Q8G as int8 rows followed by one fp16 scale per group,
+    Q4G the same with two weights per byte.
+
+    Which format goes where follows tools/convert.py rather than being a
+    free choice: it writes Q8G for embed_tokens and lm_head and Q4G for
+    every layer weight, because --trunk-bits defaults to 4. A synthetic
+    container that is Q8G throughout does not exercise the width a real
+    one is almost entirely made of — which is how a Q4G trunk that could
+    not be dequantized at load reached a release with CI green."""
 
     def __init__(self, rng):
         self.buf = bytearray()
@@ -122,6 +130,29 @@ class Trunk:
         self.buf += f16([self.rng.uniform(0.002, 0.02)
                          for _ in range(rows * ng)])
         self.index.append({"name": name, "fmt": FMT_Q8G, "off": off,
+                           "shape": list(shape), "group": GROUP,
+                           "scale_off": soff, "bytes": len(self.buf) - off})
+
+    def q4g(self, name, shape):
+        """Two weights per byte, zero point 8, one fp16 scale per group —
+        the layout model.c unpacks as
+            (i & 1) ? (byte >> 4) - 8 : (byte & 0x0F) - 8
+        so the low nibble is the even element and the high nibble the odd
+        one. Stored values are v + 8, i.e. 0..15 for v in -8..7."""
+        rows, N = 1, shape[-1]
+        for s in shape[:-1]:
+            rows *= s
+        ng = (N + GROUP - 1) // GROUP
+        off = len(self.buf)
+        # Padded out to whole groups, as the converter does. GROUP is even,
+        # so the pairing below never runs off the end.
+        vals = [self.rng.randrange(0, 16) for _ in range(rows * ng * GROUP)]
+        self.buf += bytes(vals[i] | (vals[i + 1] << 4)
+                          for i in range(0, len(vals), 2))
+        soff = len(self.buf)
+        self.buf += f16([self.rng.uniform(0.002, 0.02)
+                         for _ in range(rows * ng)])
+        self.index.append({"name": name, "fmt": FMT_Q4G, "off": off,
                            "shape": list(shape), "group": GROUP,
                            "scale_off": soff, "bytes": len(self.buf) - off})
 
@@ -264,13 +295,13 @@ def main():
         if L in kda:
             a = p + "self_attn."
             for w in ("q_proj", "k_proj", "v_proj"):
-                t.q8g(a + w + ".weight", [C_KDA, hid])
-            t.q8g(a + "b_proj.weight", [H_KDA, hid])
-            t.q8g(a + "f_a_proj.weight", [D_KDA, hid])
-            t.q8g(a + "f_b_proj.weight", [C_KDA, D_KDA])
-            t.q8g(a + "g_a_proj.weight", [D_KDA, hid])
-            t.q8g(a + "g_b_proj.weight", [C_KDA, D_KDA])
-            t.q8g(a + "o_proj.weight", [hid, C_KDA])
+                t.q4g(a + w + ".weight", [C_KDA, hid])
+            t.q4g(a + "b_proj.weight", [H_KDA, hid])
+            t.q4g(a + "f_a_proj.weight", [D_KDA, hid])
+            t.q4g(a + "f_b_proj.weight", [C_KDA, D_KDA])
+            t.q4g(a + "g_a_proj.weight", [D_KDA, hid])
+            t.q4g(a + "g_b_proj.weight", [C_KDA, D_KDA])
+            t.q4g(a + "o_proj.weight", [hid, C_KDA])
             for w in ("q_conv1d", "k_conv1d", "v_conv1d"):
                 t.f32(a + w + ".weight", [C_KDA, 1, 4])
             t.f32(a + "A_log", [1, 1, H_KDA, 1])
@@ -278,23 +309,23 @@ def main():
             t.f32(a + "o_norm.weight", [D_KDA])
         else:
             a = p + "self_attn."
-            t.q8g(a + "q_proj.weight", [nh * qd, hid])
-            t.q8g(a + "kv_a_proj_with_mqa.weight", [kvl + rope, hid])
+            t.q4g(a + "q_proj.weight", [nh * qd, hid])
+            t.q4g(a + "kv_a_proj_with_mqa.weight", [kvl + rope, hid])
             t.f32(a + "kv_a_layernorm.weight", [kvl])
-            t.q8g(a + "kv_b_proj.weight", [nh * (cfg["qk_nope_head_dim"] + vh), kvl])
-            t.q8g(a + "o_proj.weight", [hid, nh * vh])
+            t.q4g(a + "kv_b_proj.weight", [nh * (cfg["qk_nope_head_dim"] + vh), kvl])
+            t.q4g(a + "o_proj.weight", [hid, nh * vh])
         if L < cfg["first_k_dense_replace"]:
-            t.q8g(p + "mlp.gate_proj.weight", [dense, hid])
-            t.q8g(p + "mlp.up_proj.weight", [dense, hid])
-            t.q8g(p + "mlp.down_proj.weight", [hid, dense])
+            t.q4g(p + "mlp.gate_proj.weight", [dense, hid])
+            t.q4g(p + "mlp.up_proj.weight", [dense, hid])
+            t.q4g(p + "mlp.down_proj.weight", [hid, dense])
         else:
             m = p + "block_sparse_moe."
-            t.q8g(m + "gate.weight", [cfg["num_experts"], hid])
+            t.q4g(m + "gate.weight", [cfg["num_experts"], hid])
             t.f32(m + "gate.e_score_correction_bias", [cfg["num_experts"]])
             sh = moe * cfg["num_shared_experts"]
-            t.q8g(m + "shared_experts.gate_proj.weight", [sh, hid])
-            t.q8g(m + "shared_experts.up_proj.weight", [sh, hid])
-            t.q8g(m + "shared_experts.down_proj.weight", [hid, sh])
+            t.q4g(m + "shared_experts.gate_proj.weight", [sh, hid])
+            t.q4g(m + "shared_experts.up_proj.weight", [sh, hid])
+            t.q4g(m + "shared_experts.down_proj.weight", [hid, sh])
     t.f32("model.norm.weight", [hid])
     t.q8g("lm_head.weight", [cfg["vocab_size"], hid])
     with open(os.path.join(args.out, "trunk.bin"), "wb") as f:


### PR DESCRIPTION
Closes #6. Independent of #5 — this branch sits directly on `c4d45c5`.

## The bug

`WASTE_Q8=0` dequantizes the trunk once at load instead of at every use. Its branch was labelled `/* Q8G -> f32 */`, guarded `else if (!q8_off)`, and read `rows * ng * g` bytes — one byte per weight. True of Q8G alone, but the guard caught **every** non-F32 format, and `--trunk-bits` defaults to 4. On any container `tools/convert.py` produces today, the read asks for twice the bytes the tensor occupies.

What that did depended on what happened to follow the tensor in `trunk.bin`:

| container | behaviour |
|---|---|
| real (Kimi-Linear 49 B) | over-read runs off the end, `pread_all` short-reads, **load fails** |
| small | over-read succeeds into the **neighbouring tensor** — same prompt, different logits (`argmax 59` where the quantized path says `20`) |

The loud failure was the lucky case. Silently computing from the adjacent tensor's bytes is the one to worry about.

## The fix

The branch is gone. Non-F32 tensors are always loaded quantized, and when `!q8_off` the rows go through `waste_deq_row` — **the same unpacker the compute path calls** — into an f32 buffer, after which `q`/`qs` are freed and `bits`/`rowbytes`/`group` zeroed so the tensor is indistinguishable from one that was F32 on disk (`m->t` is calloc'd, and `unpack_row_i8` and friends branch on `bits` without consulting `q`).

Nothing in the load path knows a width any more, so nothing there can be wrong about one. Q3G is covered by construction rather than by a third copy of the unpacking — which is the shape of the original defect.

`embed_tokens` now stays on disk under `WASTE_Q8=0` as it does otherwise. Its rows go through the same unpacker when read, so the logits are unchanged and 1.11 GB stays out of the resident set.

## Why CI was green

`tools/make_test_container.py` wrote a **Q8G trunk throughout** — the one width the old branch handled. A real trunk is the other way round: `convert.py` writes Q8G for `embed_tokens` and `lm_head`, and Q4G for every layer weight (315 of 525 tensors on Kimi-Linear).

The synthetic container now does the same, so `waste info` reports the `Q4G/Q8G/F32` a real one does, and the check that had been passing for want of coverage now has some.

## Verification

- **Real container** (Kimi-Linear 49.12 B, converted from the released shards). `WASTE_Q8=0` loads where it used to fail, and its logits match the quantized path to **3.72e-05 max / 4.02e-06 mean** against a `1e-3` threshold. Both agree with a PyTorch oracle regenerated from that container (see #7) to ~5e-05. Suite **30 → 31 passed**.
- **Synthetic container**: `26 passed, 0 failed`. Reverting *only* `src/model.c` and keeping the new container gives `25 passed, 1 failed` — that is the regression coverage this was missing, and it now fails in CI rather than in a user's terminal.
- **ASan/UBSan** over the suite, now with the Q4G dequant inside it: `25 passed, 0 failed`, no diagnostics.
- **Fuzzer**, 200 malformed containers: `146 rejected, 54 still loaded, 0 crashed, 0 hung`.

Linux x86_64 / AVX2, `v0.6.1`.

The one remaining failure against the real container is #7 (the oracle fixture), which is unrelated and untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)