### PR TITLE
Size the automatic budget against the cgroup limit, not the host's RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ measurement is the useful part.
 `docs/LEARNED.md` carries the full reasoning; this file carries what
 changed. Each entry names the section to read for the numbers behind it.
 
+## 0.6.3 — 2026-08-02
+
+### Fixed
+
+- **The automatic budget sized against the host's RAM inside a container**
+  ([#14](https://github.com/sqliteai/waste/issues/14)). `waste_physical_ram()`
+  is `sysconf(_SC_PHYS_PAGES)` on Linux, which reports the host's `MemTotal`
+  from inside a cgroup that is allowed a fraction of it, so a `--budget`-less
+  open resolved `floor + 3x` against memory the kernel would never hand over:
+  K3 in a 32 GiB cgroup on a large host asks for ~80 GB and is killed. Unlike
+  the paging cliff of [LEARNED.md](docs/LEARNED.md) §16 this has no gradual
+  form and no cache policy softens it. The ceiling is now
+  `min(physical, cgroup limit)` — the smallest finite `memory.max` or
+  `memory.high` across the cgroup and its ancestors, since the limit is
+  hierarchical — and the rest of the resolver is unchanged. See §40.
+
+  Current pressure (`MemAvailable`, `memory.current`) was considered and
+  deliberately left out: a budget is resolved once and held for a whole run,
+  so bounding it by an instantaneous sample would make the same command on
+  the same machine two different runs. Whether it should trim the working-set
+  multiplier instead is #14, still open.
+
+### Added
+
+- `waste_usable_ram()`: physical RAM, or a smaller cgroup-v2 limit when one
+  applies — what a budget of 0 sizes against, and what an embedding host
+  should size its own ceiling from. `waste plan --json` reports it beside
+  `physical_ram_bytes`, which stays what it always was.
+
 ## 0.6.2 — 2026-08-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ tests/run.sh /nonexistent             # forces the synthetic container (what CI 
 With no container it builds a few-MB synthetic one via
 `tools/make_test_container.py` and reports SKIP — loudly — for anything
 needing real weights. A fresh clone is 29 pass / 10 skip; with both K3 and
-Kimi-Linear containers on disk it is 41 checks.
+Kimi-Linear containers on disk it is 42 checks.
 
 The download-script checks start `tests/range_server.py` on an ephemeral
 port and read the number back through `--port-file`. Keep it that way — a

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ CFLAGS  += -MMD -MP
 
 SRC := src/model.c src/kda.c src/backend.c src/ecache.c src/version.c \
        src/tokenizer.c src/waste.c src/vq.c src/vision.c src/image.c \
-       src/crc32.c
+       src/crc32.c src/memory.c
 # Match what backend.c tests for. Linux/aarch64 reports "aarch64", which
 # does not contain "arm" — the old findstring left kda_neon.c out of the
 # build while backend.c still emitted the call to it, so the link failed
@@ -217,7 +217,7 @@ waste$(EXE): cli/main.o libwaste.a
 # the two failures tests/run.sh was written to catch, so a binary that
 # `test` builds and `clean` forgets defeats the check meant to notice it.
 TESTNAMES := test_kda test_container test_forward test_tokenizer test_k3parts \
-             test_state test_vision test_image sweep
+             test_state test_vision test_image test_memory sweep
 TESTBINS  := $(addsuffix $(EXE),$(TESTNAMES))
 
 test: $(TESTBINS)
@@ -251,6 +251,11 @@ test_image$(EXE): tests/test_image.o libwaste.a
 test_vision$(EXE): tests/test_vision.o libwaste.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 test_state$(EXE): tests/test_state.o libwaste.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+# Links the cgroup reader alone, not the engine: the point of the paths
+# being parameters is that the policy is checkable in milliseconds against
+# synthetic files, with no container and no /proc on the host to depend on.
+test_memory$(EXE): tests/test_memory.o src/memory.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 %.o: %.c

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Conversion takes about 4.7 hours with three workers on the test machine. See [do
 
 Do not set `--budget` unless you have a reason to. By default WASTE chooses a
 safe memory budget, reports it, and refuses to start below the model's floor.
+Inside a container it sizes against the cgroup limit rather than the host's RAM.
 Use `./waste --help` for the complete command list.
 
 More CLI examples, including evaluation, tokenization, saved sessions, and multimodal prompts, are in [examples/README.md](examples/README.md).

--- a/cli/main.c
+++ b/cli/main.c
@@ -483,9 +483,15 @@ static int cmd_plan(int argc, char **argv)
          * so anything reading this had to work out physical RAM for itself
          * — which on Windows means neither sysconf nor /proc exists and the
          * caller reimplements GlobalMemoryStatusEx. The engine already
-         * knows; 0 when it cannot tell. */
-        printf(",\"physical_ram_bytes\":%llu",
-               (unsigned long long)waste_physical_ram());
+         * knows; 0 when it cannot tell.
+         *
+         * Both figures, because in a container they differ and only the
+         * second is the one the budget was sized against. A reader given
+         * only physical_ram_bytes there would compute a ceiling the engine
+         * never used, and conclude the engine had ignored its own rule. */
+        printf(",\"physical_ram_bytes\":%llu,\"usable_ram_bytes\":%llu",
+               (unsigned long long)waste_physical_ram(),
+               (unsigned long long)waste_usable_ram());
         if (p.vision_bytes)
             printf(",\"vision_bytes\":%llu", (unsigned long long)p.vision_bytes);
         if (o.budget)
@@ -765,7 +771,10 @@ static void show_chosen_budget(waste_ctx *c, const opts *o)
      * this is what is held, not what was allowed. */
     const uint64_t used = u.trunk_bytes + u.state_bytes + u.scratch_bytes +
                           u.min_expert_cache;
-    const uint64_t phys = waste_physical_ram();
+    /* Usable, not physical: inside a cgroup "using 20 GB of 256 GB" names a
+     * machine this process does not have, and the number that explains the
+     * choice is the one the choice was made from. */
+    const uint64_t phys = waste_usable_ram();
     char ub[32], cb[32], pb[32];
     human(used, ub, 32);
     human(u.min_expert_cache, cb, 32);

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -133,6 +133,26 @@ Kimi-Linear, is unaffected. When even the floor is above the cap the
 engine runs at the floor and says so on stderr, because the alternative
 is refusing to open a model that does technically fit.
 
+**"The machine" is `waste_usable_ram()`, not physical RAM.** They are the
+same number everywhere except a Linux cgroup, and there they differ by
+the whole ratio between the host and the limit: `sysconf(_SC_PHYS_PAGES)`
+reads the host's `MemTotal` from inside a container. A 32 GiB cgroup on a
+256 GiB host therefore saw a 224 GiB ceiling, resolved K3 at `floor + 3x`,
+and asked for 80.64 GB — 75 GiB — of a 32 GiB allowance. That failure is not the
+paging cliff above — nothing degrades, the kernel kills the process — so
+no cache policy softens it and the only fix is to see the limit. With the
+limit visible the same machine lands on the floor and runs.
+`src/memory.c` takes the smallest finite `memory.max` or
+`memory.high` over this cgroup and its ancestors, since the limit is
+hierarchical and a leaf saying `max` does not cancel a finite parent.
+
+Only *capacity* enters that reading. `MemAvailable` and `memory.current`
+are pressure, they move between the read and the allocation, and a budget
+resolved once at open cannot track them — bounding a run that lasts hours
+by an instantaneous reading makes the same command on the same machine
+two different runs. Whether current pressure should trim the multiplier
+is [issue #14](https://github.com/sqliteai/waste/issues/14), open.
+
 ### What the floor is made of
 
 | part | scales with | can it shrink? |
@@ -316,7 +336,7 @@ print:
 | `eval` | `waste_eval`, `waste_detokenize` |
 | `tokenize` / `detokenize` | `waste_tokenize`, `waste_detokenize` |
 | `bench` | `waste_get_stats` |
-| `plan` | `waste_plan_memory`, `waste_physical_ram` |
+| `plan` | `waste_plan_memory`, `waste_physical_ram`, `waste_usable_ram` |
 | `info` | `waste_model_get_info`, `waste_memory_used` |
 
 Images add four more, reachable from `run`, `chat` and `eval` via

--- a/docs/LEARNED.md
+++ b/docs/LEARNED.md
@@ -2176,3 +2176,52 @@ The method note is short. **§4 was right and stopped being the constraint,
 and nothing about §4 was wrong.** A measurement can be perfectly reproduced
 and still stop describing the system, when what changes is not the number
 but which mechanism the number was about.
+
+## 40. The machine the resolver was sizing against was not ours (2026-08-02)
+
+The default budget has one machine number in it, and until now that number
+was `waste_physical_ram()`. On Linux it is `sysconf(_SC_PHYS_PAGES) *
+sysconf(_SC_PAGESIZE)`, which reads the host's `MemTotal` — and reads
+exactly the same thing from inside a cgroup that is allowed a fraction of
+it. Every containerized run has therefore been sizing against RAM it was
+never going to be given: K3 in a 32 GiB cgroup on a 256 GiB host resolves
+`floor + 3x`, asks for about 80 GB, and is killed.
+
+**This is not §16 and it does not behave like §16.** The cliff there is a
+performance failure with a shape — the hit rate climbs, the bytes read
+fall, throughput drops eightfold, and it is visible in a sweep. A cgroup
+limit is a kill. Nothing degrades first, no allocation policy softens it,
+and the sweep that found §16 could never have found this one, because the
+machine it was swept on was not in a cgroup. It is the same class of bug
+as §27: a platform path that every green run had avoided rather than
+exercised.
+
+So the ceiling is now `min(physical, cgroup limit)`, and everything
+downstream — the 7/8 reserve, the whole-working-set stepping, the floor
+refusal — is untouched. The reader takes the smallest finite `memory.max`
+or `memory.high` across this cgroup and its ancestors: the limit is
+hierarchical, so a leaf saying `max` does not cancel a finite parent, and
+`memory.high` belongs there because a group the kernel reclaims from is a
+group whose expert cache it takes back, which is §16's mechanism arriving
+by another road.
+
+**What deliberately did not go in is current pressure.** `MemAvailable`
+and `memory.current` are the obvious next reading and they are a different
+kind of number: capacity is fixed for the life of the process, pressure
+moves between the read and the allocation. A budget is resolved once at
+`waste_open` and then held for the length of a run, so bounding it by an
+instantaneous sample makes the same command on the same machine two
+different runs — and the reason to want it, a host that is busy *now*,
+says nothing about a host that will be busy in ten minutes. Whether it
+should trim the multiplier rather than the ceiling is
+[#14](https://github.com/sqliteai/waste/issues/14), still open, and the
+proposal that opened it is what found this bug.
+
+The method note is the uncomfortable one. **Nothing here was measured.**
+The cgroup reader is covered by synthetic-file tests, `test_memory` runs
+in milliseconds on every host, and the two cases worth having — a leaf at
+`max` under a finite parent, and `docker run` without a private cgroup
+namespace, where `/proc/self/cgroup` names a path that does not exist
+under the mount — are exactly the two a real host cannot be put into on
+demand. The fix is an arithmetic change to a number that was provably the
+wrong one; it is not a throughput row and must not be quoted as one.

--- a/docs/LEARNED.md
+++ b/docs/LEARNED.md
@@ -2217,11 +2217,34 @@ should trim the multiplier rather than the ceiling is
 [#14](https://github.com/sqliteai/waste/issues/14), still open, and the
 proposal that opened it is what found this bug.
 
-The method note is the uncomfortable one. **Nothing here was measured.**
-The cgroup reader is covered by synthetic-file tests, `test_memory` runs
-in milliseconds on every host, and the two cases worth having — a leaf at
-`max` under a finite parent, and `docker run` without a private cgroup
-namespace, where `/proc/self/cgroup` names a path that does not exist
-under the mount — are exactly the two a real host cannot be put into on
-demand. The fix is an arithmetic change to a number that was provably the
-wrong one; it is not a throughput row and must not be quoted as one.
+Measured in the only place it can be, which is a container. `docker run
+--memory=6g` on a host reporting 8,319,213,568 bytes of RAM:
+`waste plan --json` gives `physical_ram_bytes` 8,319,213,568 and
+`usable_ram_bytes` **6,442,450,944** — the limit exactly. The suite's own
+budget check, run inside that cgroup, reports `usable 6.00 GB`, which is
+the resolver consuming it rather than the reader merely reading it.
+24 passed, 0 failed, 16 skipped on Linux there.
+
+Both cgroup namespace modes were exercised, and they fail differently,
+which is why the walk has to end *on* the mounted root:
+
+| mode | `/proc/self/cgroup` | where the limit is | usable |
+|---|---|---|---|
+| private (default) | `0::/` | the mounted root itself | 5–6 GiB, exact |
+| `--cgroupns=host` | `0::/docker/<id>` | that path, on the host hierarchy | 5 GiB, exact |
+
+Under `--cgroupns=host` the composed path does exist, and
+`/sys/fs/cgroup/memory.max` does **not** — confirming the assumption the
+fallback rests on, that a real unified root carries no limit and an
+unconfined host therefore still reads 0.
+
+The choice changes, not just the reading. On the synthetic container
+(floor 8,844,904, recommended 9,139,816) a 12 MiB cgroup holds
+`floor + 3x` and opens silently; a 9 MiB one puts the ceiling under the
+floor, so the engine runs at the floor and says so. Before this commit
+both read 8.32 GB and saw nothing to say.
+
+What is *not* here is a throughput row. This is arithmetic on a number
+that was provably the wrong one, and the K3-in-a-cgroup case that motivates
+it — 80.64 GB asked of a 32 GiB allowance — is derived from the resolver's
+own rule, not run.

--- a/serve/engine.py
+++ b/serve/engine.py
@@ -271,6 +271,8 @@ def _bind(lib) -> None:
     lib.waste_get_stats.argtypes = [C.c_void_p, C.POINTER(Stats)]
     lib.waste_physical_ram.restype = C.c_uint64
     lib.waste_physical_ram.argtypes = []
+    lib.waste_usable_ram.restype = C.c_uint64
+    lib.waste_usable_ram.argtypes = []
 
 
 def version() -> str:
@@ -283,6 +285,12 @@ def build_info() -> str:
 
 def physical_ram() -> int:
     return int(_lib().waste_physical_ram())
+
+
+def usable_ram() -> int:
+    """Physical RAM, or a smaller cgroup-v2 limit. What a 0 budget sizes
+    against — in a container it is the only one of the two that is true."""
+    return int(_lib().waste_usable_ram())
 
 
 def _bounded_int(name: str, value: int, lo: int, hi: int) -> int:

--- a/src/memory.c
+++ b/src/memory.c
@@ -135,14 +135,18 @@ uint64_t waste_cgroup_limit(const char *self_cgroup_path, const char *cgroup_roo
      * trusting the leaf.
      *
      * The walk ends *on* the mounted root, and that last read is not a
-     * formality — it is what covers `docker run` without a private cgroup
-     * namespace, where /proc/self/cgroup reports the host path
-     * (0::/system.slice/docker-<id>.scope) while /sys/fs/cgroup is mounted
-     * as the container's own root. Every composed directory along the way
-     * is then missing, and the limit that actually applies is sitting in
-     * the root itself. Stopping one level short would read nothing and
-     * report "unconfined" for the one deployment this exists for. An
-     * unconfined host is still 0: a real unified root has no memory.max. */
+     * formality: it is the only one that fires under a private cgroup
+     * namespace, which is what `docker run` gives by default —
+     * /proc/self/cgroup says 0::/ and the container's limit is in the root
+     * itself. Measured both ways, because they are not the same shape.
+     * With --cgroupns=host the process reads 0::/docker/<id>, that path
+     * *does* exist because the host hierarchy is mounted, and the root has
+     * no memory.max at all; a runtime that mounts only the leaf gives the
+     * mirror image. Reading every level from the composed path up to and
+     * including the root is what covers all three without having to know
+     * which one this is. An unconfined host is still 0: a real unified
+     * root carries no memory.max, which is the same fact that makes the
+     * --cgroupns=host root read nothing. */
     uint64_t cap = 0;
     for (;;) {
         cap = smaller_nonzero(cap, limits_at(dir));

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 SQLite Cloud, Inc.
+ */
+/* waste_physical_ram() answers "how big is this machine". On Linux that is
+ * sysconf(_SC_PHYS_PAGES), which reads the host's MemTotal even when the
+ * process is confined to a fraction of it, so a container gets the wrong
+ * number by the whole ratio between the host and its limit. The automatic
+ * budget then sizes against RAM it will never be allowed to touch — a
+ * 32 GiB cgroup on a 256 GiB host asks for floor + 3x and is killed. That
+ * is not the paging cliff of docs/LEARNED.md §16: nothing degrades, the
+ * kernel simply kills the process, and no cache policy can soften it.
+ *
+ * So the ceiling becomes min(physical, cgroup limit) and everything
+ * downstream is unchanged. What enters here is capacity only — the same
+ * kind of number as physical RAM, fixed for the life of the process.
+ * Current pressure (MemAvailable, memory.current) deliberately does not:
+ * it moves between the read and the allocation, and a budget resolved once
+ * at open cannot track it. Bounding a long-lived allocation by an
+ * instantaneous reading makes the same command on the same machine two
+ * different runs.
+ *
+ * memory.high counts as a limit alongside memory.max. It is the reclaim
+ * threshold rather than a kill threshold, which makes it the closer
+ * analogue of §16: a group allowed to exceed it is a group whose expert
+ * cache the kernel takes back, and a hit that costs a page fault is worse
+ * than the pread it replaced.
+ */
+
+#include "memory.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* There is no #if __linux__ in this file, on purpose. Nothing below is a
+ * Linux API — it is fopen and strtoull over paths the caller supplies — so
+ * guarding it would only mean the one platform that runs it is the one
+ * platform that never compiles it anywhere else. §27 is what that costs.
+ * On a host with no cgroups the two paths do not open and the answer is 0,
+ * which is the same answer a #else would have returned, for the price of
+ * two failed fopen() calls once per waste_open. */
+
+/* A limit file holds a byte count or the literal "max". Unlimited,
+ * unreadable and malformed all mean the same thing to a caller looking for
+ * a ceiling — nothing constrains us here — so all three answer 0 and there
+ * is no tri-state to get wrong at the call site. */
+static uint64_t read_limit(const char *dir, const char *leaf)
+{
+    char path[1600];
+    const int n = snprintf(path, sizeof path, "%s/%s", dir, leaf);
+    if (n < 0 || (size_t)n >= sizeof path) return 0;
+
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    char b[64];
+    const int got = fgets(b, sizeof b, f) != NULL;
+    fclose(f);
+    if (!got) return 0;
+
+    char *p = b, *end = NULL;
+    while (*p == ' ' || *p == '\t') p++;
+    errno = 0;
+    const unsigned long long v = strtoull(p, &end, 10);
+    if (errno || end == p) return 0;          /* "max", or anything else */
+    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
+    return *end ? 0 : (uint64_t)v;
+}
+
+static uint64_t smaller_nonzero(uint64_t a, uint64_t b)
+{
+    if (!a) return b;
+    if (!b) return a;
+    return a < b ? a : b;
+}
+
+static uint64_t limits_at(const char *dir)
+{
+    return smaller_nonzero(read_limit(dir, "memory.max"),
+                           read_limit(dir, "memory.high"));
+}
+
+/* The unified hierarchy's line in /proc/self/cgroup, which is "0::" and an
+ * absolute path. Rejects "..", because these paths are parameters and a
+ * test must not be able to walk out of the root it supplied. */
+static int unified_path(const char *path, char *out, size_t cap)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    char line[1024];
+    int found = 0;
+    while (fgets(line, sizeof line, f)) {
+        if (strncmp(line, "0::", 3)) continue;
+        const char *rel = line + 3;
+        const size_t n = strcspn(rel, "\r\n");
+        if (!n || rel[0] != '/' || n >= cap) break;
+        int bad = 0;
+        for (size_t i = 0; i + 1 < n; i++)
+            if (rel[i] == '.' && rel[i + 1] == '.' &&
+                (i == 0 || rel[i - 1] == '/') &&
+                (i + 2 == n || rel[i + 2] == '/')) bad = 1;
+        if (bad) break;
+        memcpy(out, rel, n);
+        out[n] = 0;
+        found = 1;
+        break;
+    }
+    fclose(f);
+    return found;
+}
+
+uint64_t waste_cgroup_limit(const char *self_cgroup_path, const char *cgroup_root)
+{
+    if (!cgroup_root || !*cgroup_root) return 0;
+
+    char root[1024];
+    size_t root_n = strlen(cgroup_root);
+    while (root_n > 1 && cgroup_root[root_n - 1] == '/') root_n--;
+    if (root_n >= sizeof root) return 0;
+    memcpy(root, cgroup_root, root_n);
+    root[root_n] = 0;
+
+    char dir[1600];
+    char rel[512];
+    int walked = 0;
+    if (self_cgroup_path && unified_path(self_cgroup_path, rel, sizeof rel)) {
+        const int n = snprintf(dir, sizeof dir, "%s%s", root,
+                               strcmp(rel, "/") ? rel : "");
+        walked = n > 0 && (size_t)n < sizeof dir;
+    }
+    if (!walked) snprintf(dir, sizeof dir, "%s", root);
+
+    /* memory.max is hierarchical: a leaf saying "max" does not cancel a
+     * finite parent, so keep the most restrictive ancestor rather than
+     * trusting the leaf.
+     *
+     * The walk ends *on* the mounted root, and that last read is not a
+     * formality — it is what covers `docker run` without a private cgroup
+     * namespace, where /proc/self/cgroup reports the host path
+     * (0::/system.slice/docker-<id>.scope) while /sys/fs/cgroup is mounted
+     * as the container's own root. Every composed directory along the way
+     * is then missing, and the limit that actually applies is sitting in
+     * the root itself. Stopping one level short would read nothing and
+     * report "unconfined" for the one deployment this exists for. An
+     * unconfined host is still 0: a real unified root has no memory.max. */
+    uint64_t cap = 0;
+    for (;;) {
+        cap = smaller_nonzero(cap, limits_at(dir));
+        const size_t len = strlen(dir);
+        if (len <= root_n) break;
+        char *slash = strrchr(dir, '/');
+        if (!slash || (size_t)(slash - dir) < root_n) break;
+        if ((size_t)(slash - dir) == root_n) dir[root_n] = 0;
+        else *slash = 0;
+    }
+    return cap;
+}

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 SQLite Cloud, Inc.
+ */
+/* How much RAM this process may use, which is not how big the machine is.
+ * Private: the public answer is waste_usable_ram() in waste.h. */
+
+#ifndef WASTE_MEMORY_H
+#define WASTE_MEMORY_H
+
+#include <stdint.h>
+
+/* The smallest finite cgroup-v2 memory limit applying to this process, or 0
+ * when none does — no cgroup, an unlimited one, cgroup v1, or a host that
+ * has no such thing. Both paths are parameters so the policy can be checked
+ * against synthetic files: the cases worth testing are a leaf that says
+ * "max" under a finite parent, and a /proc/self/cgroup path that does not
+ * exist under the mounted root, and neither can be arranged on the host
+ * running the suite. That also makes this reader platform-independent, so
+ * it is compiled and exercised everywhere rather than only where it fires.
+ * Production passes "/proc/self/cgroup" and "/sys/fs/cgroup". */
+uint64_t waste_cgroup_limit(const char *self_cgroup_path,
+                            const char *cgroup_root);
+
+#endif /* WASTE_MEMORY_H */

--- a/src/waste.c
+++ b/src/waste.c
@@ -23,6 +23,7 @@
 #include <time.h>
 
 #include "json.h"
+#include "memory.h"
 #include "model.h"
 #include "platform.h"
 #include "tokenizer.h"
@@ -149,6 +150,18 @@ uint64_t waste_physical_ram(void)
 #else
     return 0;
 #endif
+}
+
+/* What the budget is allowed to size against. Physical RAM is how big the
+ * machine is; this is how much of it this process may have, and on Linux
+ * the two differ by the whole ratio between a host and a container limit —
+ * sysconf reads host MemTotal from inside a cgroup. See src/memory.c. */
+uint64_t waste_usable_ram(void)
+{
+    const uint64_t phys = waste_physical_ram();
+    const uint64_t cg = waste_cgroup_limit("/proc/self/cgroup", "/sys/fs/cgroup");
+    if (!cg) return phys;
+    return (!phys || cg < phys) ? cg : phys;
 }
 
 waste_status waste_plan_memory(const char *model_path, uint32_t ctx_tokens,
@@ -394,8 +407,12 @@ waste_status waste_open(const char *model_path, const waste_cfg *cfg_in,
      * that fits. On 64 GB K3 gets floor + 1x = 46 GB, the measured
      * optimum; on 128 GB it still gets the full floor + 3x; a model whose
      * recommendation already fits, like Kimi-Linear, is unaffected. When
-     * not even one multiple fits, run at the floor and say so below. */
-    const uint64_t phys = waste_physical_ram();
+     * not even one multiple fits, run at the floor and say so below.
+     *
+     * What "the machine" means is waste_usable_ram, not physical RAM: in a
+     * cgroup those differ by the ratio between the host and the limit, and
+     * sizing against the host there is not a slow run but a killed one. */
+    const uint64_t phys = waste_usable_ram();
     const uint64_t cap = phys ? phys - phys / 8 : 0;   /* 12% left to the OS */
     uint64_t budget = cfg.ram_budget_bytes;
 
@@ -421,8 +438,8 @@ waste_status waste_open(const char *model_path, const waste_cfg *cfg_in,
      * this machine — worth saying out loud before it crawls. */
     if (cap && budget > cap)
         fprintf(stderr,
-                "waste: budget %.1f GB leaves under 12%% of this machine's "
-                "%.1f GB free\n       the OS will page out the expert cache "
+                "waste: budget %.1f GB leaves under 12%% of the %.1f GB this "
+                "process may use\n       the OS will page out the expert cache "
                 "and throughput collapses\n",
                 budget / 1073741824.0, phys / 1073741824.0);
 

--- a/src/waste.h
+++ b/src/waste.h
@@ -48,8 +48,8 @@ extern "C" {
  */
 #define WASTE_VERSION_MAJOR  0
 #define WASTE_VERSION_MINOR  6
-#define WASTE_VERSION_PATCH  2
-#define WASTE_VERSION_STRING "0.6.2"
+#define WASTE_VERSION_PATCH  3
+#define WASTE_VERSION_STRING "0.6.3"
 #define WASTE_VERSION_NUMBER (WASTE_VERSION_MAJOR * 10000 + \
                               WASTE_VERSION_MINOR * 100 + \
                               WASTE_VERSION_PATCH)
@@ -117,7 +117,7 @@ typedef struct {
      * only useful in whole multiples of one token's working set, so it
      * starts from waste_memplan.recommended_bytes (floor + 3x that set)
      * and steps down a whole multiple at a time until the total fits
-     * under 7/8 of physical RAM. It does not spend the remainder up to
+     * under 7/8 of waste_usable_ram(). It does not spend the remainder up to
      * that ceiling: the last fraction buys a little hit rate and risks
      * the OS paging the cache out, which costs far more than it gains.
      * When not even floor + 1x fits, it runs at floor_bytes.
@@ -393,6 +393,18 @@ waste_status waste_get_stats(const waste_ctx *ctx, waste_stats *out);
  * near this number is counterproductive: the OS pages out the engine's own
  * expert cache, and a hit then costs a page fault. */
 uint64_t waste_physical_ram(void);
+
+/* How much of it this process may actually use: physical RAM, or a smaller
+ * cgroup-v2 limit when one applies. This is what a budget of 0 sizes
+ * against, and it is the number a host should size its own ceiling from.
+ *
+ * The two differ only on Linux, and there they can differ by everything:
+ * sysconf(_SC_PHYS_PAGES) reports the host's RAM from inside a container,
+ * so a confined process that trusts it asks for memory the kernel will not
+ * give. That failure is a kill, not a slowdown — unlike the paging cliff
+ * waste_physical_ram warns about, no cache policy softens it. 0 when
+ * neither figure can be determined. */
+uint64_t waste_usable_ram(void);
 
 #ifdef __cplusplus
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -56,6 +56,17 @@ fi
 # ---------------------------------------------------------------- unit ----
 head_ "kernels vs the reference implementations"
 
+# Not a kernel, but it decides the default budget on every containerized
+# host and runs in milliseconds against synthetic files, so it runs early
+# and unconditionally. All of it runs everywhere: the reader takes its
+# paths as parameters, so the cases that only fire on Linux are still
+# compiled and checked on the platforms we actually develop on.
+if ./test_memory "$TMP" 2>/dev/null | grep -q "^PASS"; then
+    ok "cgroup-v2 limits vs the automatic budget's ceiling"
+else
+    no "cgroup-v2 limits"
+fi
+
 if command -v uv >/dev/null 2>&1; then
     ./test_k3parts "$TMP/k3parts.bin" >/dev/null 2>&1
     if uv run --quiet --with torch --no-project python tools/k3parts_ref.py \
@@ -375,7 +386,9 @@ for t in m.get("trunk", []):
 r = subprocess.run([WASTE, "plan", sys.argv[1], "--json"],
                    capture_output=True, text=True)
 try:
-    phys = json.loads(r.stdout)["physical_ram_bytes"]
+    # usable, not physical: this decides whether the host can hold an f32
+    # trunk, and in a container the host's RAM is not what it can hold
+    phys = json.loads(r.stdout)["usable_ram_bytes"]
 except Exception:
     phys = 0
 if phys and need > phys // 2:
@@ -607,10 +620,10 @@ head_ "RAM budget"
 # the machine — K3 asks for 80.63 GB — and a swap storm. So assert the
 # rule, not a number, and it holds on any host: the engine steps down a
 # whole token working set at a time and takes the largest of
-# floor + 3x, 2x, 1x that fits under 7/8 of physical RAM, or the floor
-# when not even one multiple does, less at most one expert record of slot
-# rounding. Filling the cap instead is what put a 27 GB cache on a 64 GB
-# machine and cost 8x throughput — docs/LEARNED.md §16.
+# floor + 3x, 2x, 1x that fits under 7/8 of the RAM this process may use,
+# or the floor when not even one multiple does, less at most one expert
+# record of slot rounding. Filling the cap instead is what put a 27 GB
+# cache on a 64 GB machine and cost 8x throughput — docs/LEARNED.md §16.
 default_budget() {
     python3 - "$1" <<'PY'
 import json, os, subprocess, sys
@@ -625,13 +638,17 @@ def j(*a):
 
 plan, info = j("plan", sys.argv[1]), j("info", sys.argv[1])
 # From the engine rather than os.sysconf, which does not exist in Windows
-# CPython at all. This is the same number the engine sized itself against,
-# so what the check still tests is the rule — floor + the largest whole
-# working set under 7/8 of RAM — and not the RAM reading, which has its
-# own platform code and no business being written twice.
-phys = plan["physical_ram_bytes"]
+# CPython at all and would read the host's RAM inside a container anyway.
+# This is the same number the engine sized itself against, so what the
+# check still tests is the rule — floor + the largest whole working set
+# under 7/8 of it — and not the RAM reading, which has its own platform
+# code and no business being written twice. It is a capacity and not a
+# pressure reading, so it is the same in this process and in the `info`
+# one below; a ceiling that moved between the two would make this check
+# fail as an engine bug on any busy machine.
+phys = plan["usable_ram_bytes"]
 if not phys:
-    print("physical RAM unknown on this host")
+    print("usable RAM unknown on this host")
     sys.exit(0)
 cap = phys - phys // 8
 # what the engine actually holds: the plan's mandatory parts plus the
@@ -646,7 +663,7 @@ for k in (3, 2, 1):
         break
 rec = plan["min_expert_cache"] // (2 * info["top_k"]) if info["top_k"] else 0
 G = 1 << 30
-print(f"{held/G:.2f} GB held, ceiling {want/G:.2f} GB, machine {phys/G:.2f} GB")
+print(f"{held/G:.2f} GB held, ceiling {want/G:.2f} GB, usable {phys/G:.2f} GB")
 sys.exit(0 if want - rec - 1 <= held <= want else 1)
 PY
 }

--- a/tests/serve/test_engine.py
+++ b/tests/serve/test_engine.py
@@ -105,6 +105,14 @@ class TestLibrary(EngineTestCase):
         ram = E.physical_ram()
         self.assertTrue(ram == 0 or ram > (1 << 28), ram)
 
+    def test_usable_ram(self):
+        # Never above physical, and only below it inside a cgroup — which
+        # this may well be running in, so both are allowed.
+        usable, ram = E.usable_ram(), E.physical_ram()
+        self.assertTrue(usable == 0 or usable > (1 << 24), usable)
+        if usable and ram:
+            self.assertLessEqual(usable, ram)
+
     def test_plan_memory_without_loading(self):
         plan = E.plan_memory(str(self.model), 512)
         self.assertGreater(plan.floor_bytes, 0)

--- a/tests/test_memory.c
+++ b/tests/test_memory.c
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 SQLite Cloud, Inc.
+ */
+/* The cgroup reader against synthetic files. Every case here is one the
+ * host running the suite cannot be put into: a machine is either in a
+ * cgroup or it is not, and the two that matter — a leaf saying "max" under
+ * a finite parent, and a /proc/self/cgroup path that does not exist under
+ * the mounted root — need a hierarchy built to order.
+ *
+ * Because the reader takes its paths as parameters it is not Linux-only
+ * code, so all of this runs on every host the suite does. That is the
+ * point: the platform that would have been the only one compiling it is
+ * the platform none of us develops on. */
+
+#include "../src/memory.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* mkdir is the one call here that is not the same on Windows, where it
+ * takes no mode. remove() rather than unlink() for the same reason: it is
+ * in <stdio.h> on every host and needs no shim at all. */
+#ifdef _WIN32
+#include <direct.h>
+#define make_dir(p) _mkdir(p)
+#else
+#include <sys/stat.h>
+#define make_dir(p) mkdir((p), 0700)
+#endif
+
+#define GiB (1ULL << 30)
+#define CHECK(x) do { if (!(x)) { \
+    fprintf(stderr, "check failed at line %d: %s\n", __LINE__, #x); \
+    return 1; \
+} } while (0)
+
+static char R[512], SELF[640], PARENT[640], CHILD[768];
+
+static int put(const char *dir, const char *leaf, const char *text)
+{
+    char path[1024];
+    snprintf(path, sizeof path, "%s/%s", dir, leaf);
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    return fputs(text, f) < 0 || fclose(f) ? -1 : 0;
+}
+
+static int rm(const char *dir, const char *leaf)
+{
+    char path[1024];
+    snprintf(path, sizeof path, "%s/%s", dir, leaf);
+    return remove(path) && errno != ENOENT ? -1 : 0;
+}
+
+static int mk(const char *path)
+{
+    return make_dir(path) && errno != EEXIST ? -1 : 0;
+}
+
+static int self_says(const char *line)
+{
+    FILE *f = fopen(SELF, "w");
+    if (!f) return -1;
+    return fputs(line, f) < 0 || fclose(f) ? -1 : 0;
+}
+
+static int hierarchy_cases(const char *tmp)
+{
+    snprintf(R, sizeof R, "%s/cgroup", tmp);
+    snprintf(SELF, sizeof SELF, "%s/self.cgroup", tmp);
+    snprintf(PARENT, sizeof PARENT, "%s/parent", R);
+    snprintf(CHILD, sizeof CHILD, "%s/child", PARENT);
+    CHECK(!mk(R) && !mk(PARENT) && !mk(CHILD));
+
+    /* Nothing anywhere is an unconfined host: a real unified root carries
+     * no memory.max, so every read fails and nothing is claimed. */
+    CHECK(!self_says("0::/parent/child\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 0);
+
+    /* The ordinary case: our own group is limited. */
+    CHECK(!put(CHILD, "memory.max", "8589934592\n"));           /* 8 GiB */
+    CHECK(waste_cgroup_limit(SELF, R) == 8 * GiB);
+
+    /* "max" is not a limit, and it does not cancel a finite ancestor.
+     * memory.max is hierarchical, so the parent still binds. */
+    CHECK(!put(CHILD, "memory.max", "max\n"));
+    CHECK(!put(PARENT, "memory.max", "17179869184\n"));         /* 16 GiB */
+    CHECK(waste_cgroup_limit(SELF, R) == 16 * GiB);
+
+    /* The most restrictive ancestor wins regardless of which one it is. */
+    CHECK(!put(CHILD, "memory.max", "4294967296\n"));           /* 4 GiB */
+    CHECK(waste_cgroup_limit(SELF, R) == 4 * GiB);
+
+    /* memory.high counts too: a group the kernel reclaims from at 2 GiB
+     * cannot hold a 4 GiB expert cache, whatever memory.max permits. */
+    CHECK(!put(CHILD, "memory.high", "2147483648\n"));          /* 2 GiB */
+    CHECK(waste_cgroup_limit(SELF, R) == 2 * GiB);
+    CHECK(!rm(CHILD, "memory.high"));
+
+    /* `docker run` without a private cgroup namespace: /proc/self/cgroup
+     * reports the host path while the mount is the container's own root.
+     * Nothing along the composed path exists; the limit is in the root.
+     * Reading it is the whole point — this is the deployment the change
+     * is for, and the version that stopped one level short reported
+     * "unconfined" here. */
+    CHECK(!rm(CHILD, "memory.max") && !rm(PARENT, "memory.max"));
+    CHECK(!put(R, "memory.max", "34359738368\n"));              /* 32 GiB */
+    CHECK(!self_says("0::/system.slice/docker-0123456789ab.scope\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 32 * GiB);
+
+    /* Same answer when /proc/self/cgroup cannot be read at all — cgroup v1,
+     * or no /proc — because the mounted root is still the truth. */
+    CHECK(waste_cgroup_limit("/nonexistent/self.cgroup", R) == 32 * GiB);
+    CHECK(waste_cgroup_limit(NULL, R) == 32 * GiB);
+
+    /* Malformed telemetry claims nothing rather than guessing. A limit
+     * read wrong is a budget sized wrong, and 0 is the safe reading. */
+    CHECK(!put(R, "memory.max", "not-a-number\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 0);
+    CHECK(!put(R, "memory.max", "\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 0);
+    CHECK(!put(R, "memory.max", "8589934592 trailing\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 0);
+    CHECK(!put(R, "memory.max", "34359738368\n"));
+
+    /* The paths are parameters, so a path that walks out of the supplied
+     * root is refused rather than followed. */
+    CHECK(!self_says("0::/../outside\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 32 * GiB);   /* fell back to root */
+    CHECK(!self_says("garbage with no unified line\n"));
+    CHECK(waste_cgroup_limit(SELF, R) == 32 * GiB);
+
+    /* A trailing slash on the root is the same root. */
+    char slashed[520];
+    snprintf(slashed, sizeof slashed, "%s/", R);
+    CHECK(!self_says("0::/parent/child\n"));
+    CHECK(waste_cgroup_limit(SELF, slashed) == 32 * GiB);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "usage: test_memory TMPDIR\n");
+        return 2;
+    }
+
+    /* No root, no answer — on every platform. */
+    CHECK(waste_cgroup_limit("/proc/self/cgroup", NULL) == 0);
+    CHECK(waste_cgroup_limit("/proc/self/cgroup", "") == 0);
+
+    if (hierarchy_cases(argv[1])) return 1;
+
+    /* The production paths, whatever this host is. Either it is in a cgroup
+     * with a limit, or nothing opens and the ceiling stays physical RAM;
+     * both are correct and the check is that neither crashes nor invents. */
+    {
+        const uint64_t live = waste_cgroup_limit("/proc/self/cgroup",
+                                                 "/sys/fs/cgroup");
+        CHECK(live == 0 || live > (1 << 20));
+    }
+
+    puts("PASS cgroup limits");
+    return 0;
+}

--- a/tests/test_memory.c
+++ b/tests/test_memory.c
@@ -99,12 +99,13 @@ static int hierarchy_cases(const char *tmp)
     CHECK(waste_cgroup_limit(SELF, R) == 2 * GiB);
     CHECK(!rm(CHILD, "memory.high"));
 
-    /* `docker run` without a private cgroup namespace: /proc/self/cgroup
-     * reports the host path while the mount is the container's own root.
-     * Nothing along the composed path exists; the limit is in the root.
-     * Reading it is the whole point — this is the deployment the change
-     * is for, and the version that stopped one level short reported
-     * "unconfined" here. */
+    /* /proc/self/cgroup names a path that is not under this mount, which
+     * is what a runtime mounting only the container's own leaf produces:
+     * nothing along the composed path exists and the limit is in the root.
+     * Reading the root is the whole point — a walk that stopped one level
+     * short would report "unconfined" here. (The `docker run` default is
+     * the easier shape, 0::/ with the limit in the root; --cgroupns=host
+     * is the third, where the composed path does exist. Same walk.) */
     CHECK(!rm(CHILD, "memory.max") && !rm(PARENT, "memory.max"));
     CHECK(!put(R, "memory.max", "34359738368\n"));              /* 32 GiB */
     CHECK(!self_says("0::/system.slice/docker-0123456789ab.scope\n"));


### PR DESCRIPTION
Fixes the half of [#14](https://github.com/sqliteai/waste/issues/14) that is unambiguously a bug. #14 stays open for the pressure question.

## The bug

`waste_physical_ram()` on Linux is `sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE)`, which reads the host's `MemTotal` — and reads exactly the same thing from inside a cgroup allowed a fraction of it. Every containerized run has been sizing the automatic budget against RAM it was never going to be given. A 32 GiB cgroup on a 256 GiB host sees a 224 GiB ceiling, resolves K3 at `floor + 3x`, and asks for 80.64 GB of a 32 GiB allowance.

**This is not §16 and does not behave like it.** That cliff is a performance failure with a shape — the hit rate climbs, the bytes read fall, throughput drops eightfold, and a sweep finds it. A cgroup limit is a kill: nothing degrades first and no cache policy softens it. It is the same class of bug as §27, a platform path that every green run had avoided rather than exercised. The repo ships `Dockerfile.test`, so it is a path we already use.

## What changed

The ceiling is `min(physical, cgroup limit)`. Everything downstream — the 7/8 reserve, the whole-working-set stepping, the floor refusal — is untouched, and so is every non-Linux host.

- `src/memory.c` takes the smallest finite `memory.max` **or `memory.high`** across this cgroup and its ancestors. The limit is hierarchical, so a leaf saying `max` does not cancel a finite parent; `memory.high` belongs there because a group the kernel reclaims from is a group whose expert cache it takes back, which is §16's mechanism arriving by another road.
- The ancestor walk reads **every level from the composed path up to and including the mounted root**. There are three shapes in the wild and they are not the same: `docker run`'s default private namespace (`0::/`, limit in the root — the last read is the *only* one that fires); `--cgroupns=host` (`0::/docker/<id>`, which does exist because the host hierarchy is mounted, while the root has no `memory.max`); and a runtime mounting only the leaf, the mirror image. Reading all of them is what makes the reader not need to know which one it is. An unconfined host is still 0 — a real unified root has no `memory.max`.
- New `waste_usable_ram()`, and `waste plan --json` reports `usable_ram_bytes` beside `physical_ram_bytes`. Without it a JSON reader in a container computes a ceiling the engine never used and concludes the engine ignored its own rule. `tests/run.sh` now asserts the budget rule against that figure — it is a capacity, so it is the same in the `plan` process and the `info` one, which a pressure reading would not have been.

## What deliberately did not change

`MemAvailable` and `memory.current` are the obvious next reading and they are a different kind of number. Capacity is fixed for the life of the process; pressure moves between the read and the allocation. A budget is resolved once at `waste_open` and held for a whole run, so bounding it by an instantaneous sample would make the same command on the same machine two different runs — and a host that is busy *now* says nothing about a host that will be busy in ten minutes. Whether pressure should trim the working-set multiplier instead is #14, still open.

No new error code either: `budget < floor_bytes → WASTE_E_RAM_BUDGET` already meant "this machine cannot hold the floor", and it now means it in a cgroup too.

## No `#if __linux__`

Nothing in the reader is a Linux API — it is `fopen` and `strtoull` over paths the caller supplies. Guarding it would mean the only platform that runs it is the only platform that never compiles it anywhere else, which is exactly §27. On a host with no cgroups the two paths do not open and the answer is 0, for the price of two failed `fopen()` calls once per `waste_open`.

So `test_memory` runs the whole policy on every host in milliseconds: the hierarchy cases, a leaf at `max` under a finite parent, `memory.high`, the namespace mismatch, `/proc/self/cgroup` unreadable, malformed telemetry, and a path that tries to walk out of the root it was given.

## Verification

**In a real cgroup.** `docker run --memory=6g`, on a host reporting 8,319,213,568 bytes of RAM:

```
physical_ram_bytes  8319213568
usable_ram_bytes    6442450944   <- the limit, exactly
```

The suite's own budget check *inside* that cgroup reports `usable 6.00 GB`, which is the resolver consuming the number rather than the reader merely reading it. Full suite on Linux there: **24 passed, 0 failed, 16 skipped** (every skip is a missing container or K3).

**Both namespace modes**, because they fail differently and that is the case for ending the walk *on* the mounted root:

| mode | `/proc/self/cgroup` | composed path exists? | root has `memory.max`? | `usable_ram_bytes` |
|---|---|---|---|---|
| private (default) | `0::/` | n/a — is the root | yes | 6 GiB, exact |
| `--cgroupns=host` | `0::/docker/<id>` | yes, host hierarchy | **no** | 5 GiB, exact |

The second row also confirms what the fallback rests on: a real unified root carries no `memory.max`, so an unconfined host still reads 0.

**The choice changes, not just the reading.** On the synthetic container (floor 8,844,904, recommended 9,139,816) a 12 MiB cgroup holds `floor + 3x` and opens silently; a 9 MiB one puts the ceiling under the floor, so the engine runs at the floor and warns. Before this branch both read 8.32 GB and had nothing to say.

**On macOS**, `tests/run.sh` with K3 and Kimi-Linear on disk: **42 passed, 0 failed, 1 skipped**, and the K3 default budget is unchanged (`46.25 GB held, ceiling 46.25 GB, usable 64.00 GB`) — `usable == physical` outside a cgroup, which is the point. Serve suite 44 OK. Both new files cross-compile clean for Windows with `x86_64-w64-mingw32-gcc -Wall -Wextra`.

**Still not a throughput row.** The K3 case that motivates the change — 80.64 GB asked of a 32 GiB allowance — is derived from the resolver's own rule, not run.

## Adjacent, on purpose

[GATES.md](https://github.com/sqliteai/waste/blob/main/docs/GATES.md) Gate 7 is open over this same resolver, but it asks about the *quantum*. This changes the ceiling and leaves the quantum alone.

Bumps to 0.6.3 with the CHANGELOG entry in the same commit, since a new exported symbol is what `WASTE_VERSION_NUMBER` exists to gate. Happy to drop that if you would rather batch the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
