### PR TITLE
docs: fix subject-verb agreement in docs/EFFICIENCY.md

### DIFF
--- a/docs/EFFICIENCY.md
+++ b/docs/EFFICIENCY.md
@@ -309,7 +309,7 @@ env var — because the question recurs for every new container.
 ### D. Batching and speculative decoding — refuted for this machine
 
 The offloading literature — SpecMoEOff (2.5x), SP-MoE, MoE-SpeQ — all
-assumes **compute is free and the transfer is the wall**. On a GPU behind
+assume **compute is free and the transfer is the wall**. On a GPU behind
 PCIe that holds. Here it does not: at the margin compute is 1.5 s/token
 against 1.62 s of I/O. They are nearly equal.
 


### PR DESCRIPTION
## Summary

Fixes a grammar issue in `docs/EFFICIENCY.md`.

## Problem

Subject-verb agreement error. 'all' is plural (referring to SpecMoEOff, SP-MoE, MoE-SpeQ), so the verb should be 'assume' not 'assumes'.

## Change

- **File**: `docs/EFFICIENCY.md` (line 312)
- **Before**: `all assumes`
- **After**: `all assume`

This is a documentation-only change with no code modifications.