### PR TITLE
README.md now offer the converted K3 container over BitTorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,34 @@ make check
 
 `make` builds the `waste` CLI and `libwaste.a`. `make check` creates a small synthetic model, so it does not download weights.
 
-### Get Kimi K3
+### Get Kimi K3, already converted
 
-The download and conversion are resumable:
+The fastest route is to download the already converted container over
+BitTorrent. It skips the 1.42 TB source download, the 4.7-hour conversion, and
+the temporary staging storage entirely — only the 982 GB container lands on
+disk. Any BitTorrent client will do; the torrent's own piece hashes verify the
+container as it arrives.
+
+```text
+magnet:?xt=urn:btih:abe7123a60b2b1171c1c4dcaa381b93c46806afe&dn=k3.waste&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce
+```
+
+With [aria2](https://aria2.github.io/), which resumes and needs no GUI:
+
+```bash
+aria2c --dir ~/models --seed-time=60 \
+  'magnet:?xt=urn:btih:abe7123a60b2b1171c1c4dcaa381b93c46806afe&dn=k3.waste&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce'
+```
+
+This writes `~/models/k3.waste`, the directory the commands below expect. Point
+`--dir` at internal NVMe storage: a container downloaded onto an external disk
+has to be copied before it is usable at full speed. Raise `--seed-time` if you
+can afford to share it back.
+
+### Get Kimi K3, from the published weights
+
+Convert it yourself if you would rather not trust a third-party copy, or if you
+already hold the original weights. The download and conversion are resumable:
 
 ```bash
 # Check required download space.


### PR DESCRIPTION
Offer the converted K3 container over BitTorrent, ahead of converting it.

Converting from the published weights is the only route README documented, and it is the expensive one: a 1.42 TB source download, 4.7 hours of conversion, and staging storage that has to exist somewhere before it can be freed. The output is a 982 GB directory that is byte-identical for everyone who runs the default conversion, so nearly all of that cost is paid to reproduce a fixed artifact. This new magnet link skips it. The only downside is that a new torrent will have to be created if the WASTE weights format changes in a future release.