### PR TITLE
tools/diskbench.c reports page-cache throughput on Linux, not disk

### DIFF
--- a/tools/diskbench.c
+++ b/tools/diskbench.c
@@ -28,11 +28,24 @@ static double now(void) {
     return t.tv_sec + t.tv_usec / 1e6;
 }
 
+/* Linux has no F_NOCACHE; the page cache is bypassed with O_DIRECT at open
+ * time instead, which is what the engine itself does (see model.c). Without it
+ * this benchmark reports page-cache throughput on Linux — e.g. 42 GB/s
+ * sequential on a drive whose link tops out at 3.9 GB/s. Buffers here are
+ * already posix_memalign'd to 4096 and the record size is a 4096 multiple, so
+ * O_DIRECT's alignment requirements are met. */
+#if defined(__linux__) && defined(O_DIRECT)
+#define DIO_FLAG O_DIRECT
+#else
+#define DIO_FLAG 0
+#endif
+
 static void nocache(int fd) {
 #ifdef __APPLE__
     fcntl(fd, F_NOCACHE, 1);
     fcntl(fd, F_RDAHEAD, 0);
 #endif
+    (void)fd;
 }
 
 static const char *g_path;
@@ -43,7 +56,7 @@ typedef struct { int id, nthreads; double bytes; } targ;
 
 static void *rand_reader(void *p) {
     targ *a = (targ *)p;
-    int fd = open(g_path, O_RDONLY);
+    int fd = open(g_path, O_RDONLY | DIO_FLAG);
     if (fd < 0) { perror("open"); return NULL; }
     nocache(fd);
     void *buf = NULL;
@@ -75,7 +88,7 @@ int main(int argc, char **argv) {
     printf("file %.1f GB, record %.1f MB, path %s\n", file_gb, rec_mb, g_path);
 
     /* 1. sequential write */
-    int fd = open(g_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = open(g_path, O_WRONLY | O_CREAT | O_TRUNC | DIO_FLAG, 0644);
     if (fd < 0) { perror("open write"); return 1; }
     nocache(fd);
     void *buf;
@@ -92,7 +105,7 @@ int main(int argc, char **argv) {
     printf("seq write   : %6.2f GB/s\n", written / dt / (1u << 30));
 
     /* 2. sequential read, cache-bypassed */
-    fd = open(g_path, O_RDONLY); nocache(fd);
+    fd = open(g_path, O_RDONLY | DIO_FLAG); nocache(fd);
     t0 = now(); size_t rd = 0; ssize_t r;
     while ((r = read(fd, buf, g_rec)) > 0) rd += r;
     dt = now() - t0; close(fd);


### PR DESCRIPTION
## `tools/diskbench.c` reports page-cache throughput on Linux, not disk

`diskbench` documents itself as measuring "random record reads, cache-bypassed
<- the number that sets tok/s", with the page cache bypassed via
"F_NOCACHE / O_DIRECT". On Linux it does neither: **`O_DIRECT` never appears in
the file**, and `nocache()` is a no-op outside macOS.

Reported numbers therefore exceed the drive's physical link limit.

### Reproduction

Samsung 970 PRO, PCIe Gen3 x4 (link ceiling **3.94 GB/s**), Ubuntu 26.04,
kernel 7.0, 16 GB file, 3 MB records:

```
$ cc -O2 -o diskbench tools/diskbench.c
$ ./diskbench /mnt/nvme/.bench 16 3 12
seq write   :   2.10 GB/s
seq read    :  44.67 GB/s  (cache bypassed)
rand  8 thr :  65.72 GB/s  -> 5.26 tok/s at 12.5 GB/token cold
```

44.67 and 65.72 GB/s are 11× and 17× the link ceiling.

### Cause

```c
static void nocache(int fd) {
#ifdef __APPLE__                 /* entire body is macOS-only */
    fcntl(fd, F_NOCACHE, 1);
    fcntl(fd, F_RDAHEAD, 0);
#endif
}
```

and all three opens are unqualified:

```c
int fd = open(g_path, O_RDONLY);                              /* rand_reader */
int fd = open(g_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);    /* seq write   */
fd = open(g_path, O_RDONLY);                                  /* seq read    */
```

The engine handles this correctly — `src/model.c:1355` notes "macOS says so with
fcntl. Linux needs O_DIRECT and Windows FILE_FLAG_NO_BUFFERING", guarded by
`#if defined(_WIN32) || (defined(__linux__) && defined(O_DIRECT))`. The tool is
out of step with the code it exists to characterise.

### Fix

Adding the flag is sufficient: the buffers are already `posix_memalign`'d to
4096 and the record size is a 4096 multiple, so `O_DIRECT`'s alignment
requirements are already satisfied.

```diff
+#if defined(__linux__) && defined(O_DIRECT)
+#define DIO_FLAG O_DIRECT
+#else
+#define DIO_FLAG 0
+#endif
+
 static void nocache(int fd) {
 #ifdef __APPLE__
     fcntl(fd, F_NOCACHE, 1);
     fcntl(fd, F_RDAHEAD, 0);
 #endif
+    (void)fd;
 }
@@
-    int fd = open(g_path, O_RDONLY);
+    int fd = open(g_path, O_RDONLY | DIO_FLAG);
@@
-    int fd = open(g_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = open(g_path, O_WRONLY | O_CREAT | O_TRUNC | DIO_FLAG, 0644);
@@
-    fd = open(g_path, O_RDONLY); nocache(fd);
+    fd = open(g_path, O_RDONLY | DIO_FLAG); nocache(fd);
```

### Verification

Same drive, same invocation, after the patch:

| | before | after | link ceiling |
|---|---|---|---|
| seq read | 44.67 GB/s | **3.15 GB/s** | 3.94 GB/s |
| random, 1 thread | 36.75 GB/s | **2.91 GB/s** | |
| random, saturated | 65.72 GB/s | **3.33 GB/s** | |

3.33 GB/s is 85% of the link ceiling and saturates at 2 threads, which is what a
Gen3 x4 drive should do.

### Unrelated, same file

The derived column prints `-> X tok/s at 12.5 GB/token cold`, where 12.5 GB/token
is K3's figure hardcoded. On a 48B model (1.61 GB/token measured) that column is
off by ~8×. Taking the per-token figure from the container's `plan --json`, or
dropping the column, would avoid the trap.