### PR TITLE
Correct torrent magnet in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ disk. Any BitTorrent client will do; the torrent's own piece hashes verify the
 container as it arrives.
 
 ```text
-magnet:?xt=urn:btih:abe7123a60b2b1171c1c4dcaa381b93c46806afe&dn=k3.waste&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce
+magnet:?xt=urn:btih:54db69b0df8baf5e617744dda5d46c90a2d0f632&dn=k3.waste&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=https%3A%2F%2Ftracker.tamersunion.org%3A443%2Fannounce
 ```
 
 With [aria2](https://aria2.github.io/), which resumes and needs no GUI:


### PR DESCRIPTION
The torrent was generated with mktorrent using its default piece length of 256 Kb. That default is fine for a few GB; it is not fine for a TB payload: the torrent stores one 20-byte SHA-1 per piece, so 4,018,567 pieces produce ~80 MB of hashes in the info dictionary alone. That breaks libtorrent-based clients.
So I regenerated another one with 16 MiB pieces.

This eases, but does not answer, sqliteai/waste#24: it is still a torrent, and the ask there is an IPFS or plain-HTTP mirror for users who cannot reach BitTorrent at all.