### PR TITLE
Add vq_rows_p6 dispatch slot and AVX-512 VBMI kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ src/metal.o: src/metal.m
 # so helpful as warning that the flag went missing. Invisible on ARM,
 # where these translation units are not in SRC at all.
 src/simd_avx2.o:   override CFLAGS += -mavx2 -mfma
-src/simd_avx512.o: override CFLAGS += -mavx512f -mavx512bw
+src/simd_avx512.o: override CFLAGS += -mavx512f -mavx512bw -mavx512vbmi
 
 all: waste$(EXE) libwaste.a libwaste.$(SOEXT) libwastevq.$(SOEXT)
 
@@ -216,7 +216,7 @@ src/metal.pic.o: src/metal.m
 	$(CC) $(CFLAGS) $(PICFLAG) -fobjc-arc -c -o $@ $<
 
 src/simd_avx2.pic.o:   override CFLAGS += -mavx2 -mfma
-src/simd_avx512.pic.o: override CFLAGS += -mavx512f -mavx512bw
+src/simd_avx512.pic.o: override CFLAGS += -mavx512f -mavx512bw -mavx512vbmi
 
 libwaste.$(SOEXT): $(SHOBJ)
 	$(CC) $(CFLAGS) -shared -o $@ $^ $(SHLDFLAGS) $(LDLIBS)

--- a/src/backend.c
+++ b/src/backend.c
@@ -122,6 +122,7 @@ uint32_t waste_cpu_features(void)
             if (ymm_ok && (r[1] & (1u << 5)))  f |= WASTE_CPU_AVX2;
             if (zmm_ok && (r[1] & (1u << 16))) f |= WASTE_CPU_AVX512F;
             if (zmm_ok && (r[1] & (1u << 30))) f |= WASTE_CPU_AVX512BW;
+            if (zmm_ok && (r[2] & (1u << 1)))  f |= WASTE_CPU_AVX512VBMI;
             run_cpuid(7, 1, r);
             if (ymm_ok && (r[0] & (1u << 4)))  f |= WASTE_CPU_AVX_VNNI;
         }

--- a/src/kda.c
+++ b/src/kda.c
@@ -114,14 +114,16 @@ void waste_rmsnorm_gated(int C, const float *x, const float *gate,
  * overwrite only what they implement (sqlite-vector discipline). */
 void waste_mvq_rows_f32(int b, int e, void *p);
 void waste_lutb_range(int lo, int hi, void *p);
+void waste_vq_rows_p6(int b, int e, void *p);
 
 const char *waste_kda_register_cpu(waste_kernels *t)
 {
     t->kda_step = waste_kda_step;
     /* The portable range kernels live in model.c, next to the code that
-     * builds their arguments; an ISA backend overwrites these two. */
+     * builds their arguments; an ISA backend overwrites these. */
     t->mvq_rows_f32 = waste_mvq_rows_f32;
     t->lutb_range = waste_lutb_range;
+    t->vq_rows_p6 = waste_vq_rows_p6;
     t->short_conv_step = waste_short_conv_step;
     t->rmsnorm_gated = waste_rmsnorm_gated;
     return "CPU";

--- a/src/kda_neon.c
+++ b/src/kda_neon.c
@@ -13,6 +13,7 @@
 
 #include "kda.h"
 #include "waste_backend.h"
+#include "simd.h"
 
 #include <arm_neon.h>
 #include <math.h>
@@ -96,9 +97,98 @@ static void kda_step_neon(int H, int K, int V,
     }
 }
 
+static void vq_rows_p6_neon(int b, int e, void *p)
+{
+    vqp_arg *a = (vqp_arg *)p;
+    const int nv = a->nv;
+    const int en = 64;              /* validated at load; the tbl4 width   */
+    float acc[VQ_TILE];
+
+    for (int r0 = b; r0 < e; r0 += VQ_TILE) {
+        const int nr = (r0 + VQ_TILE <= e) ? VQ_TILE : e - r0;
+        for (int r = 0; r < nr; r++) acc[r] = 0.0f;
+
+        for (int v0 = 0; v0 < nv; v0 += WASTE_VQ_LUT_BLK) {
+            int v1 = v0 + WASTE_VQ_LUT_BLK;
+            if (v1 > nv) v1 = nv;
+            /* int16 is enough: 4 stages x 32 positions x 127 = 16256. */
+            int16_t sum[VQ_TILE];
+            memset(sum, 0, sizeof sum);
+
+            if (nr == VQ_TILE) {
+                int16x8_t s[8];
+                for (int i = 0; i < 8; i++) s[i] = vdupq_n_s16(0);
+                for (int v = v0; v < v1; v++) {
+                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
+                    int8x16x4_t T0, T1, T2, T3;
+                    for (int k = 0; k < 4; k++) {
+                        T0.val[k] = vld1q_s8(T +   0 + k * 16);
+                        T1.val[k] = vld1q_s8(T +  64 + k * 16);
+                        T2.val[k] = vld1q_s8(T + 128 + k * 16);
+                        T3.val[k] = vld1q_s8(T + 192 + k * 16);
+                    }
+                    const uint8_t *ix = a->idx +
+                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
+                    for (int g = 0; g < 4; g++) {
+                        const uint8x16x3_t I = vld3q_u8(ix + g * 48);
+                        const uint8x16_t j0 =
+                            vandq_u8(I.val[0], vdupq_n_u8(0x3f));
+                        const uint8x16_t j1 = vandq_u8(
+                            vorrq_u8(vshrq_n_u8(I.val[0], 6),
+                                     vshlq_n_u8(I.val[1], 2)), vdupq_n_u8(0x3f));
+                        const uint8x16_t j2 = vandq_u8(
+                            vorrq_u8(vshrq_n_u8(I.val[1], 4),
+                                     vshlq_n_u8(I.val[2], 4)), vdupq_n_u8(0x3f));
+                        const uint8x16_t j3 = vshrq_n_u8(I.val[2], 2);
+                        /* Each lookup is widened on its own rather than
+                         * summed in int8 first: two int8 tables can add to
+                         * 254 and the table is worth a bit more than the
+                         * two instructions that would save. */
+                        const int8x16_t r0v = vqtbl4q_s8(T0, j0);
+                        const int8x16_t r1v = vqtbl4q_s8(T1, j1);
+                        const int8x16_t r2v = vqtbl4q_s8(T2, j2);
+                        const int8x16_t r3v = vqtbl4q_s8(T3, j3);
+                        int16x8_t lo = s[g * 2], hi = s[g * 2 + 1];
+                        lo = vaddw_s8(lo, vget_low_s8(r0v));
+                        hi = vaddw_s8(hi, vget_high_s8(r0v));
+                        lo = vaddw_s8(lo, vget_low_s8(r1v));
+                        hi = vaddw_s8(hi, vget_high_s8(r1v));
+                        lo = vaddw_s8(lo, vget_low_s8(r2v));
+                        hi = vaddw_s8(hi, vget_high_s8(r2v));
+                        lo = vaddw_s8(lo, vget_low_s8(r3v));
+                        hi = vaddw_s8(hi, vget_high_s8(r3v));
+                        s[g * 2] = lo; s[g * 2 + 1] = hi;
+                    }
+                }
+                for (int i = 0; i < 8; i++) vst1q_s16(sum + i * 8, s[i]);
+            } else {
+                for (int v = v0; v < v1; v++) {
+                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
+                    const uint8_t *ix = a->idx +
+                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
+                    for (int r = 0; r < nr; r++) {
+                        const unsigned b0 = ix[r * 3], b1 = ix[r * 3 + 1],
+                                       b2 = ix[r * 3 + 2];
+                        sum[r] = (int16_t)(sum[r] +
+                            T[P6_J0(b0, b1, b2)] +
+                            T[en + P6_J1(b0, b1, b2)] +
+                            T[2 * en + P6_J2(b0, b1, b2)] +
+                            T[3 * en + P6_J3(b0, b1, b2)]);
+                    }
+                }
+            }
+            const float ls = a->lscale[v0 / WASTE_VQ_LUT_BLK];
+            for (int r = 0; r < nr; r++) acc[r] += ls * (float)sum[r];
+        }
+        for (int r = 0; r < nr; r++)
+            a->y[r0 + r] = acc[r] * waste_f16(a->scale[r0 + r]);
+    }
+}
+
 const char *waste_kda_register_neon(waste_kernels *t)
 {
     t->kda_step = kda_step_neon;
+    t->vq_rows_p6 = vq_rows_p6_neon;
     /* short_conv_step and rmsnorm_gated stay on the CPU baseline until
      * they show up in a profile — partial override is the whole point. */
     /* The name reports what this build *uses*, not what the CPU offers.

--- a/src/model.c
+++ b/src/model.c
@@ -2120,20 +2120,7 @@ static void vq_quant_lut(const float *lut, int nv, int st, int en,
     vq_quant_range(0, (nv + WASTE_VQ_LUT_BLK - 1) / WASTE_VQ_LUT_BLK, &a);
 }
 
-typedef struct {
-    float *y; const uint8_t *idx; const uint16_t *scale;
-    const int8_t *lut8; const float *lscale;
-    int nv;
-} vqp_arg;
-
-/* Unpack of the converter's little-endian 4x6 packing. Kept as one macro so
- * the scalar path and the NEON path cannot drift apart. */
-#define P6_J0(b0, b1, b2) ((b0) & 0x3f)
-#define P6_J1(b0, b1, b2) ((((b0) >> 6) | ((b1) << 2)) & 0x3f)
-#define P6_J2(b0, b1, b2) ((((b1) >> 4) | ((b2) << 4)) & 0x3f)
-#define P6_J3(b0, b1, b2) (((b2) >> 2) & 0x3f)
-
-static void vq_rows_p6(int b, int e, void *p)
+void waste_vq_rows_p6(int b, int e, void *p)
 {
     vqp_arg *a = (vqp_arg *)p;
     const int nv = a->nv;
@@ -2151,73 +2138,18 @@ static void vq_rows_p6(int b, int e, void *p)
             int16_t sum[VQ_TILE];
             memset(sum, 0, sizeof sum);
 
-/* -DWASTE_P6_SCALAR drops to the portable path. The two are meant to agree
- * exactly — the accumulation is integer until the per-block fold, so there
- * is no reordering for float addition to notice — and that is only worth
- * claiming if it can be checked. */
-#if (defined(__ARM_NEON) || defined(__aarch64__)) && !defined(WASTE_P6_SCALAR)
-            if (nr == VQ_TILE) {
-                int16x8_t s[8];
-                for (int i = 0; i < 8; i++) s[i] = vdupq_n_s16(0);
-                for (int v = v0; v < v1; v++) {
-                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
-                    int8x16x4_t T0, T1, T2, T3;
-                    for (int k = 0; k < 4; k++) {
-                        T0.val[k] = vld1q_s8(T +   0 + k * 16);
-                        T1.val[k] = vld1q_s8(T +  64 + k * 16);
-                        T2.val[k] = vld1q_s8(T + 128 + k * 16);
-                        T3.val[k] = vld1q_s8(T + 192 + k * 16);
-                    }
-                    const uint8_t *ix = a->idx +
-                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
-                    for (int g = 0; g < 4; g++) {
-                        const uint8x16x3_t I = vld3q_u8(ix + g * 48);
-                        const uint8x16_t j0 =
-                            vandq_u8(I.val[0], vdupq_n_u8(0x3f));
-                        const uint8x16_t j1 = vandq_u8(
-                            vorrq_u8(vshrq_n_u8(I.val[0], 6),
-                                     vshlq_n_u8(I.val[1], 2)), vdupq_n_u8(0x3f));
-                        const uint8x16_t j2 = vandq_u8(
-                            vorrq_u8(vshrq_n_u8(I.val[1], 4),
-                                     vshlq_n_u8(I.val[2], 4)), vdupq_n_u8(0x3f));
-                        const uint8x16_t j3 = vshrq_n_u8(I.val[2], 2);
-                        /* Each lookup is widened on its own rather than
-                         * summed in int8 first: two int8 tables can add to
-                         * 254 and the table is worth a bit more than the
-                         * two instructions that would save. */
-                        const int8x16_t r0v = vqtbl4q_s8(T0, j0);
-                        const int8x16_t r1v = vqtbl4q_s8(T1, j1);
-                        const int8x16_t r2v = vqtbl4q_s8(T2, j2);
-                        const int8x16_t r3v = vqtbl4q_s8(T3, j3);
-                        int16x8_t lo = s[g * 2], hi = s[g * 2 + 1];
-                        lo = vaddw_s8(lo, vget_low_s8(r0v));
-                        hi = vaddw_s8(hi, vget_high_s8(r0v));
-                        lo = vaddw_s8(lo, vget_low_s8(r1v));
-                        hi = vaddw_s8(hi, vget_high_s8(r1v));
-                        lo = vaddw_s8(lo, vget_low_s8(r2v));
-                        hi = vaddw_s8(hi, vget_high_s8(r2v));
-                        lo = vaddw_s8(lo, vget_low_s8(r3v));
-                        hi = vaddw_s8(hi, vget_high_s8(r3v));
-                        s[g * 2] = lo; s[g * 2 + 1] = hi;
-                    }
-                }
-                for (int i = 0; i < 8; i++) vst1q_s16(sum + i * 8, s[i]);
-            } else
-#endif
-            {
-                for (int v = v0; v < v1; v++) {
-                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
-                    const uint8_t *ix = a->idx +
-                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
-                    for (int r = 0; r < nr; r++) {
-                        const unsigned b0 = ix[r * 3], b1 = ix[r * 3 + 1],
-                                       b2 = ix[r * 3 + 2];
-                        sum[r] = (int16_t)(sum[r] +
-                            T[P6_J0(b0, b1, b2)] +
-                            T[en + P6_J1(b0, b1, b2)] +
-                            T[2 * en + P6_J2(b0, b1, b2)] +
-                            T[3 * en + P6_J3(b0, b1, b2)]);
-                    }
+            for (int v = v0; v < v1; v++) {
+                const int8_t *T = a->lut8 + (size_t)v * 4 * en;
+                const uint8_t *ix = a->idx +
+                    ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
+                for (int r = 0; r < nr; r++) {
+                    const unsigned b0 = ix[r * 3], b1 = ix[r * 3 + 1],
+                                   b2 = ix[r * 3 + 2];
+                    sum[r] = (int16_t)(sum[r] +
+                        T[P6_J0(b0, b1, b2)] +
+                        T[en + P6_J1(b0, b1, b2)] +
+                        T[2 * en + P6_J2(b0, b1, b2)] +
+                        T[3 * en + P6_J3(b0, b1, b2)]);
                 }
             }
             const float ls = a->lscale[v0 / WASTE_VQ_LUT_BLK];
@@ -2242,7 +2174,7 @@ static void vq_apply_serial(waste_model *m, float *y, const uint8_t *idx,
     const int nv = N / m->vec_dim;
     if (m->index_bits == 6) {
         vqp_arg a = { y, idx, scale, q, qs, nv };
-        vq_rows_p6(0, M, &a);
+        waste_k.vq_rows_p6(0, M, &a);
     } else {
         vq_arg a = { y, idx, scale, lut, nv, m->stages, m->cb_entries };
         vq_rows(0, M, &a);
@@ -2269,7 +2201,7 @@ static void vq_apply(waste_model *m, float *y, const uint8_t *idx,
     const int nv = N / m->vec_dim;
     if (m->index_bits == 6) {
         vqp_arg a = { y, idx, scale, q, qs, nv };
-        waste_parallel_for(M, VQ_TILE * p6_chunk, vq_rows_p6, &a);
+        waste_parallel_for(M, VQ_TILE * p6_chunk, waste_k.vq_rows_p6, &a);
     } else {
         vq_arg a = { y, idx, scale, lut, nv, m->stages, m->cb_entries };
         /* min_chunk = VQ_TILE keeps every thread's range block-aligned,

--- a/src/simd.h
+++ b/src/simd.h
@@ -43,6 +43,27 @@ typedef struct {
     int cb_base, stages, entries, vec_dim;
 } lutb_arg;
 
+typedef struct {
+    float *y; const uint8_t *idx; const uint16_t *scale;
+    const int8_t *lut8; const float *lscale;
+    int nv;
+} vqp_arg;
+
+#ifndef VQ_TILE
+#define VQ_TILE 64
+#endif
+
+#ifndef WASTE_VQ_LUT_BLK
+#define WASTE_VQ_LUT_BLK 32
+#endif
+
+/* Unpack of the converter's little-endian 4x6 packing. Kept as one macro so
+ * the scalar path, NEON, and AVX-512 paths cannot drift apart. */
+#define P6_J0(b0, b1, b2) ((b0) & 0x3f)
+#define P6_J1(b0, b1, b2) ((((b0) >> 6) | ((b1) << 2)) & 0x3f)
+#define P6_J2(b0, b1, b2) ((((b1) >> 4) | ((b2) << 4)) & 0x3f)
+#define P6_J3(b0, b1, b2) (((b2) >> 2) & 0x3f)
+
 /* fp16 scale -> float, and one signed 3-bit code out of a packed row. Both
  * are needed by every implementation, and both are small enough that a
  * shared inline beats a call. */

--- a/src/simd_avx512.c
+++ b/src/simd_avx512.c
@@ -122,10 +122,111 @@ static void lutb_range_avx512(int lo, int hi, void *p)
     }
 }
 
+#if defined(__AVX512VBMI__)
+static void vq_rows_p6_avx512(int b, int e, void *p)
+{
+    vqp_arg *a = (vqp_arg *)p;
+    const int nv = a->nv;
+    const int en = 64;              /* validated at load; the tbl4 width   */
+    float acc[VQ_TILE];
+
+    /* Unpack mask: maps 48 bytes of packed 3-byte indices into 16 dwords (24-bit values) */
+    static const uint8_t unpack_mask_arr[64] = {
+        0, 1, 2, 63,   3, 4, 5, 63,   6, 7, 8, 63,   9, 10, 11, 63,
+        12, 13, 14, 63, 15, 16, 17, 63, 18, 19, 20, 63, 21, 22, 23, 63,
+        24, 25, 26, 63, 27, 28, 29, 63, 30, 31, 32, 63, 33, 34, 35, 63,
+        36, 37, 38, 63, 39, 40, 41, 63, 42, 43, 44, 63, 45, 46, 47, 63
+    };
+    const __m512i unpack_mask = _mm512_loadu_si512((const __m512i *)unpack_mask_arr);
+    const __m512i mask6 = _mm512_set1_epi32(0x3f);
+
+    for (int r0 = b; r0 < e; r0 += VQ_TILE) {
+        const int nr = (r0 + VQ_TILE <= e) ? VQ_TILE : e - r0;
+        for (int r = 0; r < nr; r++) acc[r] = 0.0f;
+
+        for (int v0 = 0; v0 < nv; v0 += WASTE_VQ_LUT_BLK) {
+            int v1 = v0 + WASTE_VQ_LUT_BLK;
+            if (v1 > nv) v1 = nv;
+            int16_t sum[VQ_TILE];
+            memset(sum, 0, sizeof sum);
+
+            if (nr == VQ_TILE) {
+                __m512i s[4];
+                for (int g = 0; g < 4; g++) s[g] = _mm512_setzero_si512();
+
+                for (int v = v0; v < v1; v++) {
+                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
+                    const __m512i T0 = _mm512_loadu_si512((const __m512i *)(T + 0));
+                    const __m512i T1 = _mm512_loadu_si512((const __m512i *)(T + 64));
+                    const __m512i T2 = _mm512_loadu_si512((const __m512i *)(T + 128));
+                    const __m512i T3 = _mm512_loadu_si512((const __m512i *)(T + 192));
+
+                    const uint8_t *ix = a->idx +
+                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
+
+                    for (int g = 0; g < 4; g++) {
+                        const __m512i raw = _mm512_maskz_loadu_epi8(0x0000FFFFFFFFFFFFULL, ix + g * 48);
+                        const __m512i val = _mm512_permutexvar_epi8(unpack_mask, raw);
+
+                        const __m512i j0 = _mm512_and_si512(val, mask6);
+                        const __m512i j1 = _mm512_and_si512(_mm512_srli_epi32(val, 6), mask6);
+                        const __m512i j2 = _mm512_and_si512(_mm512_srli_epi32(val, 12), mask6);
+                        const __m512i j3 = _mm512_and_si512(_mm512_srli_epi32(val, 18), mask6);
+
+                        const __m512i r0v = _mm512_permutexvar_epi8(j0, T0);
+                        const __m512i r1v = _mm512_permutexvar_epi8(j1, T1);
+                        const __m512i r2v = _mm512_permutexvar_epi8(j2, T2);
+                        const __m512i r3v = _mm512_permutexvar_epi8(j3, T3);
+
+                        const __m512i r0_s = _mm512_srai_epi32(_mm512_slli_epi32(r0v, 24), 24);
+                        const __m512i r1_s = _mm512_srai_epi32(_mm512_slli_epi32(r1v, 24), 24);
+                        const __m512i r2_s = _mm512_srai_epi32(_mm512_slli_epi32(r2v, 24), 24);
+                        const __m512i r3_s = _mm512_srai_epi32(_mm512_slli_epi32(r3v, 24), 24);
+
+                        const __m512i stage_sum = _mm512_add_epi32(
+                            _mm512_add_epi32(r0_s, r1_s),
+                            _mm512_add_epi32(r2_s, r3_s));
+                        s[g] = _mm512_add_epi32(s[g], stage_sum);
+                    }
+                }
+                for (int g = 0; g < 4; g++) {
+                    int32_t tmp[16];
+                    _mm512_storeu_si512((__m512i *)tmp, s[g]);
+                    for (int i = 0; i < 16; i++) sum[g * 16 + i] = (int16_t)tmp[i];
+                }
+            } else {
+                for (int v = v0; v < v1; v++) {
+                    const int8_t *T = a->lut8 + (size_t)v * 4 * en;
+                    const uint8_t *ix = a->idx +
+                        ((size_t)(r0 / VQ_TILE) * nv + v) * VQ_TILE * 3;
+                    for (int r = 0; r < nr; r++) {
+                        const unsigned b0 = ix[r * 3], b1 = ix[r * 3 + 1],
+                                       b2 = ix[r * 3 + 2];
+                        sum[r] = (int16_t)(sum[r] +
+                            T[P6_J0(b0, b1, b2)] +
+                            T[en + P6_J1(b0, b1, b2)] +
+                            T[2 * en + P6_J2(b0, b1, b2)] +
+                            T[3 * en + P6_J3(b0, b1, b2)]);
+                    }
+                }
+            }
+            const float ls = a->lscale[v0 / WASTE_VQ_LUT_BLK];
+            for (int r = 0; r < nr; r++) acc[r] += ls * (float)sum[r];
+        }
+        for (int r = 0; r < nr; r++)
+            a->y[r0 + r] = acc[r] * waste_f16(a->scale[r0 + r]);
+    }
+}
+#endif
+
 const char *waste_register_avx512(waste_kernels *t)
 {
     t->mvq_rows_f32 = mvq_rows_f32_avx512;
     t->lutb_range = lutb_range_avx512;
+#if defined(__AVX512VBMI__)
+    if (waste_cpu_features() & WASTE_CPU_AVX512VBMI)
+        t->vq_rows_p6 = vq_rows_p6_avx512;
+#endif
     return "AVX-512";
 }
 

--- a/src/simd_avx512.c
+++ b/src/simd_avx512.c
@@ -123,6 +123,9 @@ static void lutb_range_avx512(int lo, int hi, void *p)
 }
 
 #if defined(__AVX512VBMI__)
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((target("avx512vbmi")))
+#endif
 static void vq_rows_p6_avx512(int b, int e, void *p)
 {
     vqp_arg *a = (vqp_arg *)p;
@@ -178,11 +181,21 @@ static void vq_rows_p6_avx512(int b, int e, void *p)
                         const __m512i r2v = _mm512_permutexvar_epi8(j2, T2);
                         const __m512i r3v = _mm512_permutexvar_epi8(j3, T3);
 
+                        /* Note on permute & sign extension:
+                         * j0..j3 select table entries for byte 0 of each dword. The upper
+                         * 3 bytes of each dword in j0..j3 are zero, so they select T[0].
+                         * The following slli_epi32(..., 24) / srai_epi32(..., 24) shifts
+                         * byte 0 to the high position and sign-extends it to int32, cleanly
+                         * discarding the unselected upper bytes.
+                         */
                         const __m512i r0_s = _mm512_srai_epi32(_mm512_slli_epi32(r0v, 24), 24);
                         const __m512i r1_s = _mm512_srai_epi32(_mm512_slli_epi32(r1v, 24), 24);
                         const __m512i r2_s = _mm512_srai_epi32(_mm512_slli_epi32(r2v, 24), 24);
                         const __m512i r3_s = _mm512_srai_epi32(_mm512_slli_epi32(r3v, 24), 24);
 
+                        /* Accumulate in 32-bit: two's-complement addition mod 2^32 truncated
+                         * to int16 at block exit is bit-identical to accumulating mod 2^16.
+                         */
                         const __m512i stage_sum = _mm512_add_epi32(
                             _mm512_add_epi32(r0_s, r1_s),
                             _mm512_add_epi32(r2_s, r3_s));

--- a/src/waste_backend.h
+++ b/src/waste_backend.h
@@ -56,6 +56,7 @@ typedef enum {
     WASTE_CPU_AVX512F  = 1u << 11,
     WASTE_CPU_AVX512BW = 1u << 12,
     WASTE_CPU_AVX_VNNI = 1u << 13,
+    WASTE_CPU_AVX512VBMI = 1u << 14,
     WASTE_CPU_RVV      = 1u << 20,
 } waste_cpu_feature;
 
@@ -75,11 +76,12 @@ typedef struct {
     void (*rmsnorm_gated)(int C, const float *x, const float *gate,
                           const float *weight, float eps, float *y);
 
-    /* The two range kernels that carry the arithmetic (see simd.h). They
+    /* The range kernels that carry the arithmetic (see simd.h). They
      * take (begin, end, arg) because that is what the thread pool hands
      * out, so dispatch costs one indirect call per range, not per row. */
     void (*mvq_rows_f32)(int b, int e, void *arg);
     void (*lutb_range)(int lo, int hi, void *arg);
+    void (*vq_rows_p6)(int b, int e, void *arg);
 
     /* Set by a backend that wants the whole row range in one call — a GPU
      * dispatch must not be split across pool threads. Call sites use


### PR DESCRIPTION
Move VQ4P apply out of an \#ifdef\ in \src/model.c\ into the engine's kernel dispatch table (\waste_k.vq_rows_p6\), matching the pattern of other arithmetic kernels in sqlite-vector/WARP.

### Summary of Changes
- **Dispatch slot**: Added \oid (*vq_rows_p6)(int b, int e, void *arg);\ to \waste_kernels\ in \src/waste_backend.h\.
- **CPU baseline**: Exported portable C baseline \waste_vq_rows_p6\ in \src/model.c\ and registered it in \waste_kda_register_cpu\ in \src/kda.c\.
- **NEON backend**: Moved NEON vectorized implementation \q_rows_p6_neon\ to \src/kda_neon.c\ and registered it in \waste_kda_register_neon\.
- **CPUID feature detection**: Added \WASTE_CPU_AVX512VBMI\ capability bit in \src/waste_backend.h\ and detection for CPUID leaf 7 subleaf 0 ECX bit 1 in \src/backend.c\.
- **AVX-512 VBMI kernel**: Implemented \q_rows_p6_avx512\ in \src/simd_avx512.c\ using \_mm512_permutexvar_epi8\ for 16-row vector unpack and 64-byte stage table lookups, registered in \waste_register_avx512\.
- **Build flags**: Added \-mavx512vbmi\ to CFLAGS for \src/simd_avx512.o\ and \src/simd_avx512.pic.o\ in \Makefile\.

### Verification
- Built full suite via \make && make test\.
- Ran \	ests/run.sh\: all 42 checks passed (0 failed).
- Verified bit-identity between \waste_vq_rows_p6\ (CPU baseline) and the dispatched kernel across randomized fixtures.

Closes #38