### PR TITLE
Dump what the router thought of the experts that lost, not only the winners

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -164,6 +164,7 @@ static int q8_off = 1;     /* 1 = keep the trunk stored as int8          */
 static int sdot_on = 0;    /* 1 = also quantize activations (SDOT path)  */
 static int i8mm_on = 0;    /* SMMLA batched matmul; costs activation int8 */
 static const char *dump_route = NULL;  /* WASTE_DUMP_ROUTE, see moe_layer */
+static const char *dump_scores = NULL; /* WASTE_DUMP_SCORES, see moe_layer */
 /* Absolute position of the first token of the pass being routed. The dump
  * names each row by the token it belongs to rather than leaving a reader
  * to infer it from where the layer index wraps — which is a heuristic
@@ -193,6 +194,7 @@ static void model_opts_init(void)
     /* Read once rather than per layer per token: moe_layer runs 92
      * times a token and getenv is not free. */
     dump_route = getenv("WASTE_DUMP_ROUTE");
+    dump_scores = getenv("WASTE_DUMP_SCORES");
     /* How many of the next layer's experts to fetch on the router's guess.
      * The layer boundary holds about six reads and the prediction's
      * precision falls off past there, so that is the default. 0 is off. */
@@ -2745,6 +2747,32 @@ static void moe_layer(waste_model *m, int L, const float *in, float *out, int *r
     }
     for (int j = 0; j < K; j++) w[j] *= c->routed_scale;
     if (routed) for (int j = 0; j < K; j++) routed[j] = idx[j];
+
+    /* WASTE_DUMP_SCORES=path appends one line per (token, layer):
+     *
+     *     pos  L  v0 v1 .. v(E-1)
+     *
+     * the *selection* value for every expert, `score[e] + bias[e]` — the
+     * quantity the loop above ranks on, not the weight it later applies.
+     *
+     * WASTE_DUMP_ROUTE records the ids that won, and no question about a
+     * *different* ranking can be answered from winners alone. Anything that
+     * would reorder the top-K — a residency prior, a dynamic k, a pruning
+     * criterion — needs to know what the experts that lost were worth, and
+     * by how much they lost. A trace of the chosen cannot say.
+     *
+     * Same reasoning as the comment below, and the same economics: this is
+     * one fprintf against a rebuild plus a sweep. */
+    if (dump_scores) {
+        FILE *sf = fopen(dump_scores, "a");
+        if (sf) {
+            fprintf(sf, "%d %d", dump_pos0, L);
+            for (int e = 0; e < E; e++)
+                fprintf(sf, " %.6g", score[e] + (bias ? bias[e] : 0.0f));
+            fputc('\n', sf);
+            fclose(sf);
+        }
+    }
 
     /* WASTE_DUMP_ROUTE=path appends one line per (token, layer):
      *


### PR DESCRIPTION
`WASTE_DUMP_ROUTE` records the top-K ids and their weights. That answers every question about the ranking the router made, and none about a ranking it did not.

That gap turns out to be load-bearing. A residency prior promotes an expert the real router left just outside the top-K. A dynamic-k rule needs to know how far the k+1th sat behind the kth. A pruning criterion needs the scores of the experts it proposes to delete. All three are questions about the **losers**, and a trace of the chosen cannot say which one, or by how much.

So `WASTE_DUMP_SCORES=path` appends the whole vector, one line per (token, layer):

```
pos  L  v0 v1 .. v(E-1)
```

## Evidence

Same container, same prompt, same flags; before is the merge-base built in a sibling worktree.

| Before | After |
| --- | --- |
| <img src="https://github.com/mfethe1/warp/blob/pr-evidence/feat-dump-router-scores-84dd27b/before-scores.png?raw=1" width="450" alt="variable not read, no file written"> | <img src="https://github.com/mfethe1/warp/blob/pr-evidence/feat-dump-router-scores-84dd27b/after-scores.png?raw=1" width="450" alt="78 lines of 258 fields"> |

3 generated tokens × 26 MoE layers → 78 lines of 258 fields (pos, layer, 256 experts).

## The one detail worth checking in review

It dumps **`score[e] + bias[e]`** — the quantity the selection loop ranks on — and *not* `w[j]`, which takes `score[best]` **without** the bias and is applied after the choice is made.

Those differ, and getting it backwards would make every offline re-ranking experiment quietly disagree with the engine while looking correct. It is the sort of thing that produces a confident wrong answer rather than an obvious one, so it seemed worth saying out loud in the comment as well as here.

## Cost

Unset: one null check per layer, nothing written. `make check` is **44 passed / 0 failed / 13 skipped**, unchanged from the merge-base on this machine (Windows 11 / Ryzen 7 3700X / MSYS2 UCRT64 / gcc 16.2.0).

Set: one `fprintf` per (token, layer), same shape as the `WASTE_DUMP_ROUTE` block it sits beside. 200 tokens × 26 layers × 256 experts came to about 7.8 MB.

## Why this shape

The reasoning is the one already written above `WASTE_DUMP_ROUTE` — *"Both questions are 'is the signal there', and both are cheaper to answer from a trace than from a build"* — and so are the economics: one `fprintf` against a rebuild plus a sweep. This is the same instrument, one field wider.

I wanted it for a specific question (does preferring cache-resident experts buy anything the router lookahead has not already collected — arXiv:2412.00099), but the dump is not specific to that, which is why it is offered on its own rather than bundled with the experiment. The experiment may not survive; `docs/LEARNED.md` §54's *"what routing buys is not which experts exist … it is the per-token exclusion"* is a strong prior against anything that edits the selection, and I have not yet cleared the continuation bar the README holds `num_experts_per_token` to. The trace was worth having either way, and would be worth having to anyone testing a dynamic-k or a pruning criterion.

## Context

From standing up a native Windows x86 measurement box for #37/#38 work. Companions on the same machine: #42, #43, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5eVMiauR4Lkt8Dhc67MNb
