### PR TITLE
Prefer experts the cache already has, for ranking only

### DIFF
--- a/src/ecache.c
+++ b/src/ecache.c
@@ -593,6 +593,23 @@ void waste_ecache_hint(waste_ecache *c, int layer, const int *ids, int n)
     ec_unlock(c);
 }
 
+void waste_ecache_resident_mask(waste_ecache *c, int layer, int n, uint8_t *out)
+{
+    if (!out || n <= 0) return;
+    memset(out, 0, (size_t)n);
+    if (!c || c->n_slots <= 0) return;
+
+    ec_lock(c);
+    for (int e = 0; e < n; e++) {
+        const int si = ec_lookup(c, ec_key(layer, e));
+        /* READY only. An INFLIGHT slot has been asked for and has not
+         * arrived, so a router told it was resident would pick it and then
+         * wait on the same read it was trying to avoid. */
+        if (si >= 0 && c->slot[si].state == EC_READY) out[e] = 1u;
+    }
+    ec_unlock(c);
+}
+
 const uint8_t *waste_ecache_get(waste_ecache *c, int layer, int expert,
                                 waste_fetch_fn fetch, void *user)
 {

--- a/src/ecache.h
+++ b/src/ecache.h
@@ -167,6 +167,22 @@ void waste_ecache_io_stop(waste_ecache *c);
  * Reads for the first `depth` of them that are not resident start now, and
  * each waste_ecache_get releases one more into the pipe. Calling it with a
  * synchronous cache is a no-op, so call sites need no conditional. */
+/* Residency of a whole layer's experts, without touching any of them.
+ *
+ * `out[e]` becomes 1 when expert e of `layer` is in the cache and READY —
+ * usable with no disk read. Nothing is claimed, no recency moves, and
+ * nothing counts as a hit or a miss: this answers a question, it does not
+ * make a request. INFLIGHT deliberately reads as 0, so "resident" means
+ * arrived rather than asked for.
+ *
+ * One call per layer rather than one per expert because a single mutex
+ * covers the whole cache, and a per-expert probe would take it E times per
+ * layer per token — 83k times a token on K3.
+ *
+ * For a router that wants to prefer experts it already has (arXiv:2412.00099).
+ */
+void waste_ecache_resident_mask(waste_ecache *c, int layer, int n, uint8_t *out);
+
 void waste_ecache_hint(waste_ecache *c, int layer, const int *ids, int n);
 
 /* Speculative fill for a layer that has not routed yet. Unlike a hint these

--- a/src/model.c
+++ b/src/model.c
@@ -164,6 +164,7 @@ static int q8_off = 1;     /* 1 = keep the trunk stored as int8          */
 static int sdot_on = 0;    /* 1 = also quantize activations (SDOT path)  */
 static int i8mm_on = 0;    /* SMMLA batched matmul; costs activation int8 */
 static const char *dump_route = NULL;  /* WASTE_DUMP_ROUTE, see moe_layer */
+static const char *dump_scores = NULL; /* WASTE_DUMP_SCORES, see moe_layer */
 /* Absolute position of the first token of the pass being routed. The dump
  * names each row by the token it belongs to rather than leaving a reader
  * to infer it from where the layer index wraps — which is a heuristic
@@ -193,6 +194,7 @@ static void model_opts_init(void)
     /* Read once rather than per layer per token: moe_layer runs 92
      * times a token and getenv is not free. */
     dump_route = getenv("WASTE_DUMP_ROUTE");
+    dump_scores = getenv("WASTE_DUMP_SCORES");
     /* How many of the next layer's experts to fetch on the router's guess.
      * The layer boundary holds about six reads and the prediction's
      * precision falls off past there, so that is the default. 0 is off. */
@@ -2745,6 +2747,32 @@ static void moe_layer(waste_model *m, int L, const float *in, float *out, int *r
     }
     for (int j = 0; j < K; j++) w[j] *= c->routed_scale;
     if (routed) for (int j = 0; j < K; j++) routed[j] = idx[j];
+
+    /* WASTE_DUMP_SCORES=path appends one line per (token, layer):
+     *
+     *     pos  L  v0 v1 .. v(E-1)
+     *
+     * the *selection* value for every expert, `score[e] + bias[e]` — the
+     * quantity the loop above ranks on, not the weight it later applies.
+     *
+     * WASTE_DUMP_ROUTE records the ids that won, and no question about a
+     * *different* ranking can be answered from winners alone. Anything that
+     * would reorder the top-K — a residency prior, a dynamic k, a pruning
+     * criterion — needs to know what the experts that lost were worth, and
+     * by how much they lost. A trace of the chosen cannot say.
+     *
+     * Same reasoning as the comment below, and the same economics: this is
+     * one fprintf against a rebuild plus a sweep. */
+    if (dump_scores) {
+        FILE *sf = fopen(dump_scores, "a");
+        if (sf) {
+            fprintf(sf, "%d %d", dump_pos0, L);
+            for (int e = 0; e < E; e++)
+                fprintf(sf, " %.6g", score[e] + (bias ? bias[e] : 0.0f));
+            fputc('\n', sf);
+            fclose(sf);
+        }
+    }
 
     /* WASTE_DUMP_ROUTE=path appends one line per (token, layer):
      *

--- a/src/model.c
+++ b/src/model.c
@@ -165,6 +165,7 @@ static int sdot_on = 0;    /* 1 = also quantize activations (SDOT path)  */
 static int i8mm_on = 0;    /* SMMLA batched matmul; costs activation int8 */
 static const char *dump_route = NULL;  /* WASTE_DUMP_ROUTE, see moe_layer */
 static const char *dump_scores = NULL; /* WASTE_DUMP_SCORES, see moe_layer */
+static float ccr_lambda = 0.0f;        /* WASTE_CCR_LAMBDA, see moe_layer */
 /* Absolute position of the first token of the pass being routed. The dump
  * names each row by the token it belongs to rather than leaving a reader
  * to infer it from where the layer index wraps — which is a heuristic
@@ -195,6 +196,9 @@ static void model_opts_init(void)
      * times a token and getenv is not free. */
     dump_route = getenv("WASTE_DUMP_ROUTE");
     dump_scores = getenv("WASTE_DUMP_SCORES");
+    { const char *s = getenv("WASTE_CCR_LAMBDA");
+      ccr_lambda = s ? (float)atof(s) : 0.0f;
+      if (!(ccr_lambda > 0.0f)) ccr_lambda = 0.0f; }   /* also catches NaN */
     /* How many of the next layer's experts to fetch on the router's guess.
      * The layer boundary holds about six reads and the prediction's
      * precision falls off past there, so that is the default. 0 is off. */
@@ -2725,6 +2729,37 @@ static void moe_layer(waste_model *m, int L, const float *in, float *out, int *r
     float *score = sc + E;
     for (int e = 0; e < E; e++) score[e] = 1.0f / (1.0f + expf(-sc[e]));
 
+    /* Cache-conditional routing (arXiv:2412.00099), off unless WASTE_CCR_LAMBDA
+     * asks for it. Experts already in the cache get a bonus **for ranking
+     * only** — `w[j]` below still takes the untouched `score[best]`, so the
+     * gating weights are exactly what the model computed and only the choice
+     * of which K to run moves.
+     *
+     * The bonus is scaled by this layer's own logit range so one lambda means
+     * the same thing in a layer whose scores span 0.9 and one whose scores
+     * span 0.02. The paper uses a running mean of that range; this uses the
+     * range of the token in hand, which needs no per-layer state — and static
+     * mutable state would be wrong here anyway, since waste.h promises several
+     * models can be open in one process.
+     *
+     * This changes what the model outputs. LEARNED §54 is the reason it can
+     * never become a default: "what routing buys is not which experts exist,
+     * nor how they are weighted on average — it is the per-token exclusion",
+     * and this edits precisely that. It is an instrument for measuring the
+     * hit-rate/KL trade, and it stays one until a KL curve says otherwise. */
+    uint8_t resident[1024];
+    float ccr_bump = 0.0f;
+    if (ccr_lambda > 0.0f && E <= (int)sizeof resident) {
+        waste_ecache_resident_mask(&m->cache, L, E, resident);
+        float lo = 1e30f, hi = -1e30f;
+        for (int e = 0; e < E; e++) {
+            const float v = score[e] + (bias ? bias[e] : 0.0f);
+            if (v < lo) lo = v;
+            if (v > hi) hi = v;
+        }
+        ccr_bump = ccr_lambda * (hi - lo);
+    }
+
     int idx[64];
     float w[64];
     for (int j = 0; j < K; j++) {
@@ -2734,11 +2769,12 @@ static void moe_layer(waste_model *m, int L, const float *in, float *out, int *r
             int taken = 0;
             for (int p = 0; p < j; p++) if (idx[p] == e) { taken = 1; break; }
             if (taken) continue;
-            const float v = score[e] + (bias ? bias[e] : 0.0f);
+            float v = score[e] + (bias ? bias[e] : 0.0f);
+            if (ccr_bump > 0.0f && resident[e]) v += ccr_bump;
             if (v > bv) { bv = v; best = e; }
         }
         idx[j] = best;
-        w[j] = score[best];
+        w[j] = score[best];          /* unmodified: ranking moved, gating did not */
     }
     if (c->renorm && K > 1) {
         float s = 0;
@@ -2755,14 +2791,14 @@ static void moe_layer(waste_model *m, int L, const float *in, float *out, int *r
      * the *selection* value for every expert, `score[e] + bias[e]` — the
      * quantity the loop above ranks on, not the weight it later applies.
      *
-     * WASTE_DUMP_ROUTE records the ids that won, and no question about a
-     * *different* ranking can be answered from winners alone. Anything that
-     * would reorder the top-K — a residency prior, a dynamic k, a pruning
-     * criterion — needs to know what the experts that lost were worth, and
-     * by how much they lost. A trace of the chosen cannot say.
-     *
-     * Same reasoning as the comment below, and the same economics: this is
-     * one fprintf against a rebuild plus a sweep. */
+     * WASTE_DUMP_ROUTE records the ids that won. Any question about a
+     * *different* ranking needs the ones that lost too: a residency prior
+     * (arXiv:2412.00099) promotes an expert the real router placed outside
+     * the top-K, and a trace of winners cannot say which one or by how much.
+     * So this dumps the whole vector, and the question "would a cache-aware
+     * ranking hit more often, and how far does the distribution move" is
+     * answerable offline — which is the same reasoning, and the same
+     * economics, as the comment below. */
     if (dump_scores) {
         FILE *sf = fopen(dump_scores, "a");
         if (sf) {


### PR DESCRIPTION
**Stacked on #45.** I would have targeted that branch directly, but GitHub will not accept a base branch that lives on a fork, so this targets `main` and therefore **carries #45's commit as well as its own**:

- `c4afbde` — `WASTE_DUMP_SCORES`, which is **#45**, review it there
- `33b4d2e` — this PR's actual change

**Read only the second commit's diff here.** If #45 merges first, this rebases to just `33b4d2e` and I will force-push it clean.

**Read this first, because it is the reason this is a knob and not a proposal to change anything:** this does **not** reproduce the greedy continuation the way `num_experts_per_token=8` does. README accepted top-8 against *two* bars — KL 0.037 **and** "it reproduces top-16's greedy continuation on the prompts tested". This clears the KL bar at a smaller value and stays on-task everywhere I looked, but the text is not byte-identical. That asymmetry is the whole reason it is offered off by default, and I would rather lead with it than have you find it.

## What it does

Experts already in the cache get a bonus **for ranking only**, per [arXiv:2412.00099](https://arxiv.org/abs/2412.00099):

```c
v = score[e] + bias[e] + lambda * layer_logit_range * resident[e]
```

`w[j]` still takes the untouched `score[best]`, so the gating weights are exactly what the model computed and only the *choice of which K to run* moves. Off unless `WASTE_CCR_LAMBDA` is set; unset, `make check` is 44 passed / 0 failed / 13 skipped, unchanged.

## Measured, Kimi-Linear, lookahead ON

| lambda | hit% | GB/token | bytes saved | KL from lambda=0 |
|---|---|---|---|---|
| 0 | 70.6 | 0.322 | — | 0 |
| 0.05 | 76.9 | 0.294 | 8.7% | 0.0166 |
| **0.10** | **82.5** | **0.249** | **22.7%** | **0.0232** |
| 0.25 | 87.0 | 0.227 | 29.5% | 0.0525 |
| 0.50 | 88.2 | 0.224 | 30.4% | 0.0670 |

Against README's own prices: **top-8 is KL 0.037 and ships; top-4 is KL 0.118 and was refused.** lambda=0.1 sits below the accepted one.

### Evidence

| Before (lambda=0) | After (lambda=0.1) |
| --- | --- |
| <img src="https://github.com/mfethe1/warp/blob/pr-evidence/feat-cache-conditional-routing-a4a4424/before-ccr.png?raw=1" width="450" alt="70.6% hit, 0.323 GB/token"> | <img src="https://github.com/mfethe1/warp/blob/pr-evidence/feat-cache-conditional-routing-a4a4424/after-ccr.png?raw=1" width="450" alt="82.5% hit, 0.249 GB/token"> |

`tok/s` is filtered out of both frames on purpose — an unrelated download was writing to the same disk throughout. Hit rate and bytes are deterministic counters; throughput on this box is not, and I would rather show you nothing than show you a number I cannot stand behind.

## Why I believe it is additive to the lookahead rather than the same gain twice

That was the obvious way for this to be worthless: a prefetcher that makes about-to-be-needed experts resident, and a prior that prefers resident experts, could easily be chasing the same misses. §35 prices the lookahead at 14–19% → 38–40% demand hit rate on its own.

**`lambda=0` reproduces the engine's independently measured 70.6% baseline exactly**, with the lookahead on in every arm. The +11.9 points at 0.10 are on top of it.

An offline simulator I wrote first said +20 points at the same lambda. It was wrong by ~40% because it modelled no lookahead — its baseline sat 26 points under the engine's. Mentioning it because it is the kind of over-estimate this idea invites.

## The §54 check

`docs/LEARNED.md` §54 is the reason I did not stop at a hit-rate number: `k3-k16` had **100% hit, zero misses** and ran at **half** the speed, because `kda` and `mla` — which touch no experts — went 1.6x slower from ~45 GB being permanently hot.

First profile run here looked exactly like that in reverse: everything sped up ~1.5x including `kda`. **Interleaved repeats showed it was slow-first-run noise** — by rep2 the two arms were within 1.8% and `kda` was 3.39s vs 3.42s. **No machine-wide effect.** Plausibly because this only reduces misses inside an already-bounded 1.65 GB cache, rather than making an entire working set permanently resident.

## Quality, beyond KL

Greedy `--temp 0`, three prompt types, lambda 0 / 0.05 / 0.1 / 0.25:

- **Factual recall** (planets, strongest magnetic field): every lambda gives the correct order, answers Jupiter, and gives the correct mechanism. The numeric details wobble — but the *baseline* conflates surface field strength with magnetic moment, so the variants shuffle an imprecision that was already there.
- **Technical explanation**: all accurate and on-task. lambda=0.25 is arguably more precise than baseline.
- **Code** (longest strictly-increasing run), graded by **executing** it against 7 cases rather than reading its docstring: **7/7 correct at every lambda**, including 0.25. Worth noting the baseline's own example comment is wrong (`[10,9,2,5,7,8] -> 2`; it is 4) while lambda=0.25 got both of its right — comment arithmetic is this model's baseline behaviour, not something the prior introduces.

**No compounding.** I expected a state-dependent perturbation (this one depends on cache contents, which shift as generation proceeds) might accumulate where top-k's fixed perturbation does not. Across 160- and 300-token generations, late text is as clean as early text at every lambda. Recorded as unsupported rather than refuted — two lengths on one model is not a proof.

## What this does not establish

- **Kimi-Linear only.** K3 is top-16-of-896 over a ~950 GB expert set — a completely different residency regime, where the cache holds a far smaller fraction. The signal could be weaker (less worth preferring) or stronger (more tail to avoid). §54's k3-k16 is the standing warning against assuming transfer, and I have no K3 container yet (downloading).
- **KL is one position on one prompt.** §25 is the standing warning about a number taken once.
- **The continuation bar is not cleared**, as above.
- One deviation from the paper: it scales by the layer's *instantaneous* logit range rather than a running mean, because static mutable state would be wrong when `waste.h` promises several models open in one process.

Happy to drop it, restructure it as a manifest field rather than an env var, or hold it until there is a K3 number to pair with it.

## Context

Native Windows x86 measurement box (Zen 2, 128 GB, PCIe 4.0 NVMe) stood up for #37/#38. Companions: #42, #43, #44, #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5eVMiauR4Lkt8Dhc67MNb
