### PR TITLE
The three Windows fixes that were verified in issue threads and never landed

### DIFF
--- a/src/ecache.c
+++ b/src/ecache.c
@@ -101,29 +101,44 @@ static void  ec_volatile(waste_ecache *c, int si) { (void)c; (void)si; }
 #include <sys/mman.h>
 int waste_wire(void *p, size_t n) { return mlock(p, n) == 0; }
 #else
-/* VirtualLock is bounded by the process *maximum working set*, not by
- * available memory, and the default maximum is far below any cache worth
- * wiring. So this wired nothing at all on Windows: 5928 of 5928 slots
- * refused with ERROR_WORKING_SET_QUOTA on a machine with 54 GB free and
- * nothing paging (#36, gap 5). mlock has no equivalent requirement, which
- * is why the port worked everywhere else and this went unnoticed.
+/* VirtualLock is bounded by the process working set, not by available
+ * memory, and the default is far below any cache worth wiring. So this
+ * wired nothing at all on Windows: 5928 of 5928 slots refused with
+ * ERROR_WORKING_SET_QUOTA on a machine with 54 GB free and nothing paging
+ * (#36, gap 5). mlock has no equivalent requirement, which is why the port
+ * worked everywhere else and this went unnoticed.
  *
- * Raise the ceiling on demand rather than up front: waste_wire is handed one
- * slot at a time and never learns the total, so the first refusal is the
- * only place the size actually needed is known. SetProcessWorkingSetSize
- * takes both bounds, so the current minimum is read back and preserved —
- * passing a minimum above the maximum fails the call outright.
+ * The bound is the *minimum* working set, not the maximum — "the maximum
+ * number of pages that a process can lock is equal to the number of pages
+ * in its minimum working set minus a small overhead". The first fix for
+ * this raised the maximum and deliberately preserved the minimum, and so
+ * wired exactly as much as before: nothing. Measured on the reporter's host
+ * rather than reasoned about — the maximum went from 1.3 MB to 2049 MB and
+ * the lock still failed with 1453; raising both bounds made the same lock
+ * succeed. So `lo` has to move, and `hi` is carried up with it because a
+ * minimum above the maximum fails the call outright.
  *
- * If the raise is refused — it can need SE_INC_WORKING_SET_NAME, which a
- * service account may not hold — latch and stop asking. The caller's
- * accounting is unchanged, since a latched call still reports failure; what
- * goes away is thousands of syscalls that cannot succeed. Reporting the
- * failure honestly is the existing behaviour and stays: an engine that
- * refused to open because it could not wire its cache would be worse than
- * one running with a pageable cache.
+ * That makes this a stronger request than it looks. Raising the minimum
+ * tells Windows to keep that many pages resident for this process, which is
+ * the point when wiring an expert cache — but the host gives up that memory,
+ * and `grow` is how much it gives up.
  *
- * Unverified on a real Windows host: no machine here has one. It builds
- * under both toolchains and the failure path is the previous behaviour. */
+ * Raise on demand rather than up front: waste_wire is handed one slot at a
+ * time and never learns the total, so the first refusal is the only place
+ * the size actually needed is known.
+ *
+ * If the raise is refused — a job object with a working-set cap will refuse
+ * it — latch and stop asking. The caller's accounting is unchanged, since a
+ * latched call still reports failure; what goes away is thousands of
+ * syscalls that cannot succeed, which cost ~4% in the original report.
+ * Reporting the failure honestly is the existing behaviour and stays: an
+ * engine that refused to open because it could not wire its cache would be
+ * worse than one running with a pageable cache.
+ *
+ * SE_INC_WORKING_SET_NAME is *not* required for this: the reporter's probe
+ * raised both bounds successfully with the privilege disabled, so the
+ * AdjustTokenPrivileges path an earlier version of this comment anticipated
+ * does not have to be written. */
 static int wire_quota_exhausted;      /* raise refused; stop trying */
 
 int waste_wire(void *p, size_t n)
@@ -138,11 +153,18 @@ int waste_wire(void *p, size_t n)
         return 0;
     }
     /* Room for this slot and the ones behind it, so the raise is not paid
-     * once per slot. Overshooting costs nothing: the maximum is a ceiling
-     * the process may reach, not a reservation. */
+     * once per slot. Overshooting is not free here, unlike when this raised
+     * only the maximum: the minimum is a reservation the host honours, so
+     * `grow` is memory taken from the rest of the machine. One slot plus
+     * as much again is the smallest step that still amortises. */
     const SIZE_T grow = n + (n < (64u << 20) ? (64u << 20) : n);
-    if (hi > (SIZE_T)-1 - grow || !SetProcessWorkingSetSize(GetCurrentProcess(),
-                                                            lo, hi + grow)) {
+    if (lo > (SIZE_T)-1 - grow) {
+        wire_quota_exhausted = 1;
+        return 0;
+    }
+    const SIZE_T need = lo + grow;
+    if (!SetProcessWorkingSetSize(GetCurrentProcess(), need,
+                                  need > hi ? need : hi)) {
         wire_quota_exhausted = 1;
         return 0;
     }

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -70,8 +70,12 @@ def atomic_copyfile(src, dst):
 
 
 def atomic_json(path, value):
+    # newline="\n" so a container converted on Windows is byte-identical to
+    # one converted anywhere else. Python's text mode translates, the engine
+    # parses either, and nothing fails loudly — what breaks is every gate
+    # that hashes a container to prove its provenance. #36 gap 2.
     tmp = path + ".tmp"
-    with io.open(tmp, "w", encoding="utf-8") as out:
+    with io.open(tmp, "w", encoding="utf-8", newline="\n") as out:
         json.dump(value, out, indent=1)
         out.flush()
         os.fsync(out.fileno())
@@ -1400,7 +1404,7 @@ def main():
               f"manifest listed: {', '.join(dropped)}", file=sys.stderr)
 
     manifest_tmp = manifest_path + ".tmp"
-    with open(manifest_tmp, "w") as f:
+    with open(manifest_tmp, "w", newline="\n") as f:   # see atomic_json
         json.dump(manifest, f, indent=1)
         f.flush()
         os.fsync(f.fileno())

--- a/tools/diskbench.c
+++ b/tools/diskbench.c
@@ -247,7 +247,15 @@ static void *rand_reader(void *p) {
     double got = 0;
     for (int i = 0; i < g_reps; i++) {
         seed = seed * 1103515245u + 12345u;
-        off_t off = (off_t)(seed % nrec) * g_rec;
+        /* int64_t, not off_t, which is a signed 32-bit long under LLP64 —
+         * MSYS2 UCRT64, the documented Windows path — and truncated every
+         * offset at the default 8 GB file. The loud half wrapped negative
+         * and waste_pread refused it, which cost ~40% off the random rows
+         * and inverted them with thread count. The quiet half wrapped
+         * positive and read the wrong place *successfully*, keeping the
+         * working set inside the first 2 GiB — an SSD's SLC cache, which
+         * is the flattery this whole tool exists to avoid. #36 gap 4. */
+        int64_t off = (int64_t)(seed % nrec) * (int64_t)g_rec;
         int64_t r = waste_pread(fd, buf, g_rec, off);
         if (r != (int64_t)g_rec) { fprintf(stderr, "short read %lld: %s\n", (long long)r, strerror(errno)); break; }
         got += r;
@@ -274,7 +282,7 @@ int main(int argc, char **argv) {
      * cannot be derived from what was measured does not get printed. */
     double gb_tok = argc > 5 ? atof(argv[5]) : 0.0;
     g_file = (size_t)(file_gb * (1u << 30));
-    g_rec  = (size_t)(rec_mb * (1u << 20)) & ~4095UL;
+    g_rec  = (size_t)(rec_mb * (1u << 20)) & ~(size_t)4095;
     /* A record under one page rounds to zero and divides by it two screens
      * further down, as a crash rather than as a usage error. */
     if (!g_rec || g_file < g_rec) {

--- a/tools/make_test_container.py
+++ b/tools/make_test_container.py
@@ -260,7 +260,13 @@ def write_tokenizer(outdir):
 
     base = len(tokens)
     specials = [{"id": base + i, "text": s} for i, s in enumerate(SPECIALS)]
-    with open(os.path.join(outdir, "specials.json"), "w") as f:
+    # newline="\n" on every JSON the container carries. Python's text mode
+    # translates on Windows, so the same seed builds a byte-different
+    # container there. The engine parses it either way and nothing fails
+    # loudly — what breaks is any gate that hashes a container to prove
+    # provenance. #36 gap 2, one layer in.
+    with open(os.path.join(outdir, "specials.json"), "w",
+              newline="\n") as f:
         json.dump(specials, f, indent=1)
 
     return base + len(SPECIALS)
@@ -443,7 +449,11 @@ def main():
         "layers": layers,
         "trunk": t.index,
     }
-    with open(os.path.join(args.out, "manifest.json"), "w") as f:
+    # See the note beside specials.json above: this container is hashed by
+    # tests/run.sh to date the rotary fixture, so a CRLF manifest reads as
+    # "regenerate me" on Windows against a fixture that is perfectly good.
+    with open(os.path.join(args.out, "manifest.json"), "w",
+              newline="\n") as f:
         json.dump(manifest, f, indent=1)
 
     total = sum(os.path.getsize(os.path.join(args.out, f))

--- a/tools/requant_vision.py
+++ b/tools/requant_vision.py
@@ -121,7 +121,9 @@ def main():
         os.fsync(tf.fileno())
 
     tmp = man_path + ".tmp"
-    with io.open(tmp, "w", encoding="utf-8") as f:
+    # newline="\n": a manifest rewritten on Windows must stay byte-comparable
+    # with the container convert.py built. #36 gap 2.
+    with io.open(tmp, "w", encoding="utf-8", newline="\n") as f:
         json.dump(man, f, indent=1)
     os.replace(tmp, man_path)          # the container flips in one step
     print(f"appended {added / 2**20:.0f} MB, manifest updated")


### PR DESCRIPTION
Three fixes that were reported, diagnosed and verified by other people, and were
still sitting in issue threads rather than in the tree. Two are from #36's
follow-up run; the third is one I found while checking that report and it turns
out the report was right and the reply here was wrong.

**Overlap with #43, stated up front.** @mfethe1's PR fixes the same `off_t`
defect with the same one-line change, independently diagnosed. I have not
closed it and would rather that one merge if you prefer — this branch carries
the fix only so the three Windows defects land together. If #43 goes in first,
the middle commit here drops to just the `~4095UL` half.

---

## 1. `VirtualLock` is bounded by the *minimum* working set

cf3ecc6 raised the process maximum and deliberately preserved the minimum. The
minimum is the bound — *"the maximum number of pages that a process can lock is
equal to the number of pages in its minimum working set minus a small
overhead"* — so the fix wired exactly as much as the bug did: nothing. 5928 of
5928 slots refused, the same count at the same budget as the original report.

@GTSUltear measured it rather than reasoning about it: a standalone probe raised
the maximum from 1.3 MB to 2049 MB and the same `VirtualLock` still failed with
1453; raising both bounds made it succeed. This is their patch, with the
comments brought in line.

Two things the same probe settled, both now recorded where the code is:

- **`SE_INC_WORKING_SET_NAME` is not required.** The raise succeeded with the
  privilege disabled, so `ERROR_WORKING_SET_QUOTA` was never about the
  privilege and the `AdjustTokenPrivileges` path the old comment anticipated
  does not have to be written.
- **The comment beside `grow` had become false.** Overshooting was free when
  this raised only the maximum, because a maximum is a ceiling. A minimum is a
  reservation the host honours, so `grow` is now memory taken from the rest of
  the machine. That is a real cost and it is stated rather than left implied.

The latch stays: a job object with a working-set cap still refuses the raise,
and the latch is what keeps that from costing 5928 doomed syscalls — ~4% in the
original report.

## 2. `diskbench` truncated its offset through a 32-bit `off_t`

`waste_pread` takes `int64_t` and splits it into `ReadFile`'s
`Offset`/`OffsetHigh` pair precisely so a read past 2 GiB works.
`rand_reader` handed it an `off_t`, which under LLP64 is a signed 32-bit long.
The default file size is 8 GB, so this was the default path.

The quiet failure mode is the one that matters: offsets that wrapped *positive*
did not fail at all — they read the wrong place successfully, keeping the whole
working set inside the first 2 GiB, which sits in a consumer SSD's SLC cache and
DRAM. That is the flattery this tool exists to avoid.

@mfethe1's before/after, three passes per cell, Zen 2 / PCIe 4.0:

```
diskbench PATH 8 12 4    before               after
short reads              7 x "-1: No error"   none
rand  1 thr              0.36 GB/s            1.48 GB/s
rand  2 thr              0.11 GB/s            2.23 GB/s
rand  4 thr              0.06 GB/s            2.25 GB/s
seq write / seq read     2.25 / 2.17          2.21 / 2.13
```

`docs/GATES.md` Gate H and the README's 12.78 vs 0.94 GB/s are **unaffected** —
measured on macOS, where `off_t` is 64-bit. Confirmed: the patched tool still
reports 9.6–12.5 GB/s on the internal SSD here.

Also folds in `~4095UL` → `~(size_t)4095`, which @mfethe1 flagged in #43 and
left out as a defect he had not measured. Nothing observable changes — it only
bites a record size ≥ 4 GiB — but this file already carried one truncation that
looked like a measurement.

## 3. A container's JSON went through Python text mode

@GTSUltear reported that the rotary fixture declares itself stale on Windows,
and my reply assumed it was the same staleness already skipping here. **It is
not.** The fixture is fine:

```
$ python3 tools/make_test_container.py --rope --seed 0 rope.waste
got  7ae7f6c06a6c8956b668d334c2b14ae9a7d94e9adc1bbbc89db3c30563b6510b
want 7ae7f6c06a6c8956b668d334c2b14ae9a7d94e9adc1bbbc89db3c30563b6510b
```

`manifest.json` and `specials.json` were opened in text mode, so on Windows
Python writes CRLF, the container hashes differently, and the provenance gate
cf3ecc6 added reports *"regenerate me"* against a fixture that is perfectly
good. That is **#36 gap 2 one layer in** — CRLF out of a Python stdout — landing
on the gate written to catch a different problem.

The gate is right and stays. What was wrong is that the artefact it hashes was
not reproducible across platforms in the first place.

**This is the one place I widened scope, so trim it if you would rather.**
`convert.py` (`atomic_json` and the manifest write) and `requant_vision.py` have
the identical defect on the JSON of containers people actually ship: a K3
container converted on Windows would not be byte-comparable with one converted
anywhere else. Nothing fails loudly there, because the hand-written parser takes
CRLF as ordinary JSON whitespace — which is exactly why it would have gone
unnoticed until some future gate hashed a manifest and blamed the weights.
Fixing the test generator and leaving the converter seemed like #24's shape: the
magnet corrected in the prose and left in the `aria2c` command six lines below.

---

## Verification

- `make` and `make test` clean. `diskbench` builds `-Werror` natively **and**
  cross for `x86_64-w64-mingw32`, and `src/ecache.c` cross-compiles `-Werror`
  under mingw — which is the only way to check that code from here, since macOS
  never compiles it.
- The macOS container hash is **unchanged**, so the shipped fixture stays valid
  and Windows now agrees with it rather than needing a new one.
- **53 passed, 0 failed, 6 skipped** against Kimi-Linear and K3.

**Neither Windows fix ran on a real Windows host from here** — same caveat as
cf3ecc6, and it is the reason gap 5 needed a second round. Both are @GTSUltear's
own patches, verified on their machine at two budgets with two passes each
(2706 and 5928 cache slots wired, 0.96 GB of trunk at both), so the evidence
exists; it is just not evidence this repository produced.

## One thing noticed while doing it, not fixed here

Running the suite on `main` in a worktree for a baseline gave **52 passed, 1
failed** on the first run and 53/0/6 on an identical second run. I did not
capture which check, and it did not reproduce. Not caused by anything in this
branch — `main` does not have it — but there is an intermittent check somewhere,
which is worth knowing given #30 closed one of the same species.

Closes #36 gaps 4 and 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
