### PR TITLE
Add Kimi K2 native tool calling for chat.json models

### DIFF
--- a/serve/__main__.py
+++ b/serve/__main__.py
@@ -240,11 +240,19 @@ examples:
         print(f"thinking {'off by default' if args.no_thinking else 'on'}"
               f" — reasoning_effort per request")
     else:
-        # Serving from chat.json rather than XTML. Say what is missing, in
-        # the same breath as saying it works — a client that sends `tools`
-        # and gets a 400 should not be the first time this is mentioned.
-        print(f"chat     from {model}/chat.json — plain conversation only, "
-              f"no tools,\n         no reasoning channel, no images")
+        # Serving from chat.json rather than XTML. Report capabilities from
+        # the format actually discovered in this container's tokenizer.
+        # Kimi K2 may carry its native tool protocol even though chat.json
+        # itself only describes the ordinary conversation turns.
+        tool_status = (
+            "native tools"
+            if srv.chat_format.tool_markers
+            else "no tools"
+        )
+        print(
+            f"chat     from {model}/chat.json — conversation + {tool_status}, "
+            f"\n         no reasoning channel, no images"
+        )
 
     shown = args.host if ":" not in args.host else f"[{args.host}]"
     print(f"\nlistening on http://{shown}:{args.port}  "

--- a/serve/chatfmt.py
+++ b/serve/chatfmt.py
@@ -196,11 +196,20 @@ class ChatFormat:
         without knowing which — the two formats differ in what they can
         express, not in how they are asked.
         """
+        segments: list[Segment] = []
+
         if tools:
-            raise ChatFormatError(
-                "this container is served from its chat.json, which cannot "
-                "express tool definitions; drop 'tools', or use a Kimi K3 "
-                "container, whose XTML format carries them", param="tools")
+            # Kimi K2 native tool declaration format.  Keep structural
+            # markers separate from the JSON payload so caller-controlled
+            # strings cannot be interpreted as model markup.
+            segments.append(
+                Segment("<|im_system|>tool_declare<|im_middle|>",
+                        markup=True)
+            )
+            segments.append(
+                Segment(json.dumps(tools, separators=(",", ":")))
+            )
+            segments.append(Segment("<|im_end|>", markup=True))
         for name in ("tool_choice", "response_format", "response_schema"):
             if kwargs.get(name) is not None:
                 raise ChatFormatError(
@@ -216,15 +225,32 @@ class ChatFormat:
                 "this container is served from its chat.json, which cannot "
                 "place an image")
 
-        segments: list[Segment] = []
         for i, message in enumerate(messages):
             role = message.get("role")
             role = _ROLE_ALIASES.get(role, role)
-            if role == "tool" or message.get("tool_calls"):
-                raise ChatFormatError(
-                    "this container is served from its chat.json, which "
-                    "cannot express a tool call or its result",
-                    param=f"messages[{i}]")
+
+            # Kimi K2 represents a tool result as a system-style turn whose
+            # content begins with "## Return of <tool_call_id>".
+            if role == "tool":
+                pair = self.roles.get("system")
+                if pair is None:
+                    raise ChatFormatError(
+                        f'messages[{i}] is a tool result, but this '
+                        f'container\'s chat.json has no system turn',
+                        param=f"messages[{i}].role")
+                tool_call_id = message.get("tool_call_id")
+                if not tool_call_id:
+                    raise ChatFormatError(
+                        f"messages[{i}] is a tool result without "
+                        "tool_call_id",
+                        param=f"messages[{i}].tool_call_id")
+                prefix, suffix = pair
+                segments.append(Segment(prefix, markup=True))
+                segments.append(Segment(f"## Return of {tool_call_id}\n"))
+                segments.extend(_content_segments(message.get("content"), i))
+                segments.append(Segment(suffix, markup=True))
+                continue
+
             pair = self.roles.get(role)
             if pair is None:
                 raise ChatFormatError(
@@ -234,6 +260,50 @@ class ChatFormat:
             prefix, suffix = pair
             segments.append(Segment(prefix, markup=True))
             segments.extend(_content_segments(message.get("content"), i))
+
+            tool_calls = message.get("tool_calls")
+            if tool_calls:
+                if role != "assistant":
+                    raise ChatFormatError(
+                        f"messages[{i}] carries tool_calls on a non-assistant "
+                        "turn",
+                        param=f"messages[{i}].tool_calls")
+
+                segments.append(
+                    Segment("<|tool_calls_section_begin|>", markup=True)
+                )
+
+                for j, call in enumerate(tool_calls):
+                    call_id = call.get("id")
+                    function = call.get("function") or {}
+                    arguments = function.get("arguments", "")
+
+                    if not call_id:
+                        raise ChatFormatError(
+                            f"messages[{i}].tool_calls[{j}] has no id",
+                            param=f"messages[{i}].tool_calls[{j}].id")
+
+                    if not isinstance(arguments, str):
+                        arguments = json.dumps(
+                            arguments, separators=(",", ":")
+                        )
+
+                    segments.append(
+                        Segment("<|tool_call_begin|>", markup=True)
+                    )
+                    segments.append(Segment(str(call_id)))
+                    segments.append(
+                        Segment("<|tool_call_argument_begin|>", markup=True)
+                    )
+                    segments.append(Segment(arguments))
+                    segments.append(
+                        Segment("<|tool_call_end|>", markup=True)
+                    )
+
+                segments.append(
+                    Segment("<|tool_calls_section_end|>", markup=True)
+                )
+
             segments.append(Segment(suffix, markup=True))
 
         if add_generation_prompt:

--- a/serve/chatfmt.py
+++ b/serve/chatfmt.py
@@ -46,10 +46,10 @@ import io
 import json
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from .regions import Delta
+from .regions import Delta, ToolCall
 from .xtml import Segment
 
 # The markup that has to exist in the tokenizer. Anything of this shape in
@@ -61,6 +61,14 @@ _MARKER_RE = re.compile(r"<\|[^|>]*\|>")
 _ROLE_ALIASES = {"developer": "system"}
 
 _ROLES = ("system", "user", "assistant")
+
+_KIMI_TOOL_MARKERS = (
+    "<|tool_calls_section_begin|>",
+    "<|tool_calls_section_end|>",
+    "<|tool_call_begin|>",
+    "<|tool_call_argument_begin|>",
+    "<|tool_call_end|>",
+)
 
 
 class ChatFormatError(ValueError):
@@ -94,11 +102,14 @@ class ChatFormat:
     opening: str
     stop_marker: str
     stop_id: int
+    tool_markers: dict[int, str] = field(default_factory=dict)
 
     @property
     def markers(self) -> dict[int, str]:
-        """The parser's marker table: what ends the assistant's turn."""
-        return {self.stop_id: self.stop_marker}
+        """Control-token ids understood by the reply parser."""
+        out = {self.stop_id: self.stop_marker}
+        out.update(self.tool_markers)
+        return out
 
     # ---- loading --------------------------------------------------------
 
@@ -173,8 +184,31 @@ class ChatFormat:
                     f"chat format disagree")
             ids[text] = got[0]
 
-        return cls(roles=roles, opening=opening, stop_marker=stop_marker,
-                   stop_id=ids[stop_marker])
+        # Kimi K2 carries a richer native tool-call protocol in reserved
+        # tokenizer tokens even though chat.json itself only describes the
+        # ordinary conversation turns. Discover those markers defensively:
+        # they count as structure only when every required marker is a real
+        # single special token in this container.
+        discovered: dict[int, str] = {}
+        candidates: list[tuple[int, str]] = []
+
+        for text in _KIMI_TOOL_MARKERS:
+            got = engine.tokenize(text, markup=True)
+            if len(got) != 1:
+                candidates = []
+                break
+            candidates.append((got[0], text))
+
+        if len(candidates) == len(_KIMI_TOOL_MARKERS):
+            discovered = dict(candidates)
+
+        return cls(
+            roles=roles,
+            opening=opening,
+            stop_marker=stop_marker,
+            stop_id=ids[stop_marker],
+            tool_markers=discovered,
+        )
 
     # ---- rendering ------------------------------------------------------
 
@@ -199,6 +233,14 @@ class ChatFormat:
         segments: list[Segment] = []
 
         if tools:
+            if not self.tool_markers:
+                raise ChatFormatError(
+                    "this container is served from its chat.json, which "
+                    "cannot express tool definitions because its tokenizer "
+                    "does not carry the Kimi K2 native tool markers",
+                    param="tools",
+                )
+
             # Kimi K2 native tool declaration format.  Keep structural
             # markers separate from the JSON payload so caller-controlled
             # strings cannot be interpreted as model markup.
@@ -338,48 +380,141 @@ def _content_segments(content: Any, index: int) -> list[Segment]:
 
 
 class PlainParser:
-    """Reading back a reply that has no structure but its ending.
+    """Read a chat.json reply, including Kimi K2 native tool calls.
 
-    RegionParser's counterpart for a chat.json container, with the surface
-    server.py uses: feed_token, finished, finish, content, reasoning,
-    tool_calls, openai_message. There is no element stack and there are no
-    channels, because the format has none — everything the model emits is
-    the answer until the turn's stop token arrives.
-
-    Token-driven only. RegionParser also has a text path, for hosts without
-    token ids and for the XTML goldens; there is nothing here that needs
-    one, and a scanning path would reintroduce exactly the ambiguity the
-    id-driven one exists to avoid — a model quoting `<|im_end|>` in an
-    answer would end its own turn.
+    Structure is recognized only from tokenizer marker ids. Marker-looking
+    text carried by an ordinary token remains ordinary model content.
     """
 
     def __init__(self, *, markers: Optional[dict[int, str]] = None):
         self._markers = dict(markers or {})
-        self.reasoning = ""          # never set: no channel to fill it
+        self.reasoning = ""
         self.content = ""
-        self.tool_calls: list[Any] = []
+        self.tool_calls: list[ToolCall] = []
         self._done = False
+
+        # Kimi K2 tool-call parsing state.
+        self._tool_state = "content"
+        self._tool_header = ""
+        self._tool_arguments = ""
+        self._current_tool: Optional[ToolCall] = None
 
     @property
     def finished(self) -> bool:
         return self._done
 
+    def _marker(self, token_id: int) -> Optional[str]:
+        return self._markers.get(token_id)
+
+    def _begin_tool_call(self) -> None:
+        self._tool_header = ""
+        self._tool_arguments = ""
+        self._current_tool = None
+        self._tool_state = "header"
+
+    def _parse_tool_header(self) -> ToolCall:
+        """Parse Kimi's `functions.<name>:<index>` call header."""
+        raw = self._tool_header.strip()
+
+        if raw.startswith("functions."):
+            raw = raw[len("functions."):]
+
+        name = raw
+        index = len(self.tool_calls)
+
+        if ":" in raw:
+            maybe_name, maybe_index = raw.rsplit(":", 1)
+            if maybe_name:
+                name = maybe_name
+            try:
+                index = int(maybe_index)
+            except ValueError:
+                pass
+
+        return ToolCall(name=name, index=index)
+
     def feed_token(self, token_id: int, piece: str) -> Delta:
         delta = Delta()
+
         if self._done:
             return delta
-        if token_id in self._markers:
+
+        marker = self._marker(token_id)
+
+        if marker == "<|im_end|>":
             self._done = True
             return delta
-        if piece:
-            self.content += piece
-            delta.content = piece
+
+        if marker == "<|tool_calls_section_begin|>":
+            self._tool_state = "section"
+            return delta
+
+        if marker == "<|tool_call_begin|>":
+            self._begin_tool_call()
+            return delta
+
+        if marker == "<|tool_call_argument_begin|>":
+            if self._tool_state == "header":
+                self._current_tool = self._parse_tool_header()
+                self.tool_calls.append(self._current_tool)
+                self._tool_state = "arguments"
+            return delta
+
+        if marker == "<|tool_call_end|>":
+            if self._current_tool is not None:
+                self._current_tool.json_block = self._tool_arguments
+            self._current_tool = None
+            self._tool_state = "section"
+            return delta
+
+        if marker == "<|tool_calls_section_end|>":
+            self._current_tool = None
+            self._tool_state = "content"
+            return delta
+
+        # Unknown structural markers retain the old plain-parser behavior:
+        # a real control-token id ends the generated turn.
+        if marker is not None:
+            self._done = True
+            return delta
+
+        if not piece:
+            return delta
+
+        if self._tool_state == "header":
+            self._tool_header += piece
+            return delta
+
+        if self._tool_state == "arguments":
+            self._tool_arguments += piece
+            if self._current_tool is not None:
+                self._current_tool.json_block = self._tool_arguments
+                delta.tool_calls.append(self._current_tool.index)
+            return delta
+
+        if self._tool_state == "section":
+            # Ignore stray ordinary text between Kimi tool-call structures.
+            return delta
+
+        self.content += piece
+        delta.content = piece
         return delta
 
     def finish(self) -> Delta:
-        """Nothing is ever held back, so there is nothing to flush."""
+        """Flush any in-progress Kimi tool argument block."""
+        if self._current_tool is not None:
+            self._current_tool.json_block = self._tool_arguments
         return Delta()
 
     def openai_message(self) -> dict:
-        return {"role": "assistant",
-                "content": self.content if self.content else None}
+        message = {
+            "role": "assistant",
+            "content": self.content if self.content else None,
+        }
+
+        if self.tool_calls:
+            message["tool_calls"] = [
+                call.to_openai() for call in self.tool_calls
+            ]
+
+        return message

--- a/tests/serve/test_chatfmt.py
+++ b/tests/serve/test_chatfmt.py
@@ -39,6 +39,15 @@ from tests.serve.fake_engine import FakeEngine, LINEAR_MARKERS   # noqa: E402
 SHIPPED = REPO / "examples" / "chat-kimi-linear.json"
 CHATML = REPO / "examples" / "chat.json"
 
+KIMI_K2_MARKERS = {
+    **LINEAR_MARKERS,
+    21: "<|tool_calls_section_begin|>",
+    22: "<|tool_calls_section_end|>",
+    23: "<|tool_call_begin|>",
+    24: "<|tool_call_argument_begin|>",
+    25: "<|tool_call_end|>",
+}
+
 
 class Base(unittest.TestCase):
     """A container directory holding whatever chat.json the test wants."""
@@ -78,8 +87,32 @@ class TestLoad(Base):
         fmt = self.load(SHIPPED)
         self.assertEqual(fmt.stop_marker, "<|im_end|>")
         self.assertEqual(fmt.stop_id, 15)
-        self.assertEqual(fmt.markers, {15: "<|im_end|>"})
+        self.assertEqual(fmt.markers[15], "<|im_end|>")
         self.assertEqual(sorted(fmt.roles), ["assistant", "system", "user"])
+
+    def test_kimi_tool_markers_are_discovered_when_available(self):
+        fmt = self.load(SHIPPED, markers=KIMI_K2_MARKERS)
+
+        self.assertEqual(
+            fmt.markers[21],
+            "<|tool_calls_section_begin|>",
+        )
+        self.assertEqual(
+            fmt.markers[22],
+            "<|tool_calls_section_end|>",
+        )
+        self.assertEqual(
+            fmt.markers[23],
+            "<|tool_call_begin|>",
+        )
+        self.assertEqual(
+            fmt.markers[24],
+            "<|tool_call_argument_begin|>",
+        )
+        self.assertEqual(
+            fmt.markers[25],
+            "<|tool_call_end|>",
+        )
 
     def test_markup_the_tokenizer_lacks_is_refused_at_load(self):
         """examples/chat.json is ChatML, and <|im_start|> is not in this
@@ -167,12 +200,15 @@ class TestRender(Base):
         self.assertIn(contains, str(cm.exception))
 
     def test_tools(self):
-        segs = self.render(
+        fmt = self.load(SHIPPED, markers=KIMI_K2_MARKERS)
+
+        segs = fmt.build_chat_segments(
             [{"role": "user", "content": "hi"}],
             tools=[{
                 "type": "function",
                 "function": {"name": "f", "parameters": {}},
             }],
+            thinking=False,
         )
 
         self.assertEqual(
@@ -307,7 +343,10 @@ class TestKimiK2ToolProtocol(Base):
 
     def setUp(self):
         super().setUp()
-        self.fmt = self.load(SHIPPED)
+        self.fmt = self.load(
+            SHIPPED,
+            markers=KIMI_K2_MARKERS,
+        )
 
     def test_kimi_k2_tool_declaration(self):
         tools = [{
@@ -377,3 +416,114 @@ class TestKimiK2ToolProtocol(Base):
         )
         self.assertIn("<|tool_call_end|>", rendered)
         self.assertIn("## Return of call_1", rendered)
+
+# ---------------------------------------------------------------------------
+# Kimi K2 native generated tool-call parsing
+# ---------------------------------------------------------------------------
+
+class TestKimiK2ToolParser(unittest.TestCase):
+
+    MARKERS = {
+        1001: "<|im_end|>",
+        1002: "<|tool_calls_section_begin|>",
+        1003: "<|tool_calls_section_end|>",
+        1004: "<|tool_call_begin|>",
+        1005: "<|tool_call_argument_begin|>",
+        1006: "<|tool_call_end|>",
+    }
+
+    def parser(self):
+        return PlainParser(markers=self.MARKERS)
+
+    def feed(self, parser, items):
+        for token_id, piece in items:
+            parser.feed_token(token_id, piece)
+
+    def test_kimi_tool_call_is_parsed(self):
+        p = self.parser()
+
+        self.feed(p, [
+            (2000, "I'll check the weather."),
+            (1002, "<|tool_calls_section_begin|>"),
+            (1004, "<|tool_call_begin|>"),
+            (2001, "functions.get_weather:0"),
+            (1005, "<|tool_call_argument_begin|>"),
+            (2002, '{"city": "Paris"}'),
+            (1006, "<|tool_call_end|>"),
+            (1003, "<|tool_calls_section_end|>"),
+            (1001, "<|im_end|>"),
+        ])
+
+        self.assertEqual(
+            p.content,
+            "I'll check the weather.",
+        )
+
+        self.assertEqual(len(p.tool_calls), 1)
+
+        call = p.tool_calls[0]
+
+        self.assertEqual(call.name, "get_weather")
+        self.assertEqual(call.index, 0)
+        self.assertEqual(call.json_block, '{"city": "Paris"}')
+
+        msg = p.openai_message()
+
+        self.assertEqual(msg["role"], "assistant")
+        self.assertEqual(
+            msg["content"],
+            "I'll check the weather.",
+        )
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        self.assertEqual(
+            msg["tool_calls"][0]["function"]["name"],
+            "get_weather",
+        )
+        self.assertEqual(
+            msg["tool_calls"][0]["function"]["arguments"],
+            '{"city": "Paris"}',
+        )
+
+    def test_literal_marker_text_remains_content(self):
+        p = self.parser()
+
+        self.feed(p, [
+            (
+                2000,
+                "literal <|tool_call_begin|> text"
+            ),
+            (1001, "<|im_end|>"),
+        ])
+
+        self.assertEqual(
+            p.content,
+            "literal <|tool_call_begin|> text",
+        )
+        self.assertEqual(p.tool_calls, [])
+
+    def test_kimi_tool_call_delta_reports_change(self):
+        p = self.parser()
+
+        p.feed_token(
+            1002,
+            "<|tool_calls_section_begin|>",
+        )
+        p.feed_token(
+            1004,
+            "<|tool_call_begin|>",
+        )
+        p.feed_token(
+            2000,
+            "functions.get_weather:0",
+        )
+        p.feed_token(
+            1005,
+            "<|tool_call_argument_begin|>",
+        )
+
+        delta = p.feed_token(
+            2001,
+            '{"city":"Paris"}',
+        )
+
+        self.assertIn(0, delta.tool_calls)

--- a/tests/serve/test_chatfmt.py
+++ b/tests/serve/test_chatfmt.py
@@ -167,9 +167,25 @@ class TestRender(Base):
         self.assertIn(contains, str(cm.exception))
 
     def test_tools(self):
-        self.refuses("tool definitions",
-                     tools=[{"type": "function",
-                             "function": {"name": "f", "parameters": {}}}])
+        segs = self.render(
+            [{"role": "user", "content": "hi"}],
+            tools=[{
+                "type": "function",
+                "function": {"name": "f", "parameters": {}},
+            }],
+        )
+
+        self.assertEqual(
+            segs[0].text,
+            "<|im_system|>tool_declare<|im_middle|>",
+        )
+        self.assertTrue(segs[0].markup)
+
+        self.assertIn('"name":"f"', segs[1].text)
+        self.assertFalse(segs[1].markup)
+
+        self.assertEqual(segs[2].text, "<|im_end|>")
+        self.assertTrue(segs[2].markup)
 
     def test_thinking(self):
         self.refuses("no reasoning channel", thinking=True)
@@ -179,14 +195,41 @@ class TestRender(Base):
                      response_format={"type": "json_object"})
 
     def test_a_tool_result_turn(self):
-        self.refuses("tool call",
-                     [{"role": "tool", "content": "42", "tool_call_id": "a"}])
+        segs = self.render([
+            {"role": "tool", "content": "42", "tool_call_id": "a"}
+        ])
+
+        rendered = "".join(s.text for s in segs)
+
+        self.assertIn(
+            "<|im_system|>system<|im_middle|>",
+            rendered,
+        )
+        self.assertIn("## Return of a\n42", rendered)
+        self.assertIn("<|im_end|>", rendered)
 
     def test_an_assistant_turn_carrying_tool_calls(self):
-        self.refuses("tool call",
-                     [{"role": "assistant", "content": None, "tool_calls": [
-                         {"id": "a", "function": {"name": "f",
-                                                  "arguments": "{}"}}]}])
+        segs = self.render([
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "a",
+                    "function": {
+                        "name": "f",
+                        "arguments": "{}",
+                    },
+                }],
+            }
+        ])
+
+        rendered = "".join(s.text for s in segs)
+
+        self.assertIn("<|tool_calls_section_begin|>", rendered)
+        self.assertIn("<|tool_call_begin|>a", rendered)
+        self.assertIn("<|tool_call_argument_begin|>{}", rendered)
+        self.assertIn("<|tool_call_end|>", rendered)
+        self.assertIn("<|tool_calls_section_end|>", rendered)
 
     def test_an_image_part(self):
         self.refuses("cannot place one", [{"role": "user", "content": [
@@ -255,3 +298,82 @@ class TestPlainParser(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+# ---------------------------------------------------------------------------
+# Kimi K2 native tool protocol — development tests
+# ---------------------------------------------------------------------------
+
+class TestKimiK2ToolProtocol(Base):
+
+    def setUp(self):
+        super().setUp()
+        self.fmt = self.load(SHIPPED)
+
+    def test_kimi_k2_tool_declaration(self):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "required": ["city"]
+                }
+            }
+        }]
+
+        segs = self.fmt.build_chat_segments(
+            [{"role": "user", "content": "weather in Paris?"}],
+            tools=tools,
+            thinking=False,
+        )
+
+        rendered = "".join(s.text for s in segs)
+
+        self.assertIn(
+            "<|im_system|>tool_declare<|im_middle|>",
+            rendered,
+        )
+        self.assertIn('"name":"get_weather"', rendered)
+        self.assertIn("<|im_end|>", rendered)
+
+    def test_kimi_k2_assistant_tool_call_round_trip_render(self):
+        messages = [
+            {"role": "user", "content": "weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "18 C",
+            },
+        ]
+
+        segs = self.fmt.build_chat_segments(
+            messages,
+            thinking=False,
+        )
+
+        rendered = "".join(s.text for s in segs)
+
+        self.assertIn("<|tool_calls_section_begin|>", rendered)
+        self.assertIn("<|tool_call_begin|>call_1", rendered)
+        self.assertIn(
+            '<|tool_call_argument_begin|>{"city":"Paris"}',
+            rendered,
+        )
+        self.assertIn("<|tool_call_end|>", rendered)
+        self.assertIn("## Return of call_1", rendered)

--- a/tests/serve/test_server.py
+++ b/tests/serve/test_server.py
@@ -845,3 +845,159 @@ class TestConcurrency(ServerTestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+# ---------------------------------------------------------------------------
+# Kimi K2 native tool protocol over the real HTTP surface
+# ---------------------------------------------------------------------------
+
+class TestKimiK2ToolsFromChatJson(TestChatFromChatJson):
+
+    KIMI_K2_MARKERS = {
+        **LINEAR_MARKERS,
+        21: "<|tool_calls_section_begin|>",
+        22: "<|tool_calls_section_end|>",
+        23: "<|tool_call_begin|>",
+        24: "<|tool_call_argument_begin|>",
+        25: "<|tool_call_end|>",
+    }
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="serve-kimi-k2-tools-")
+        self.addCleanup(shutil.rmtree, self.dir, True)
+
+        shutil.copyfile(
+            REPO / "examples" / "chat-kimi-linear.json",
+            Path(self.dir) / "chat.json",
+        )
+
+        self.engine_kwargs = {
+            "no_markers": True,
+            "model_path": self.dir,
+            "markers": dict(self.KIMI_K2_MARKERS),
+        }
+
+        ServerTestCase.setUp(self)
+
+    def test_tools_are_refused_by_name(self):
+        """Kimi K2 overrides the base refusal: native markers enable tools."""
+        self.engine.reply = self.kimi_tool_reply()
+
+        status, body = self.chat(tools=[{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object"},
+            },
+        }])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            body["choices"][0]["finish_reason"],
+            "tool_calls",
+        )
+
+    @staticmethod
+    def kimi_tool_reply():
+        return (
+            "I'll check the weather."
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>"
+            "functions.get_weather:0"
+            "<|tool_call_argument_begin|>"
+            '{"city":"Paris"}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "<|im_end|>"
+        )
+
+    def test_kimi_k2_tool_call_non_streaming(self):
+        self.engine.reply = self.kimi_tool_reply()
+
+        status, body = self.chat(tools=[{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object"},
+            },
+        }])
+
+        self.assertEqual(status, 200)
+
+        choice = body["choices"][0]
+
+        self.assertEqual(
+            choice["finish_reason"],
+            "tool_calls",
+        )
+
+        self.assertEqual(
+            choice["message"]["content"],
+            "I'll check the weather.",
+        )
+
+        calls = choice["message"]["tool_calls"]
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            calls[0]["function"]["name"],
+            "get_weather",
+        )
+        self.assertEqual(
+            json.loads(calls[0]["function"]["arguments"]),
+            {"city": "Paris"},
+        )
+
+    def test_kimi_k2_tool_call_streaming(self):
+        self.engine.reply = self.kimi_tool_reply()
+
+        events = self.stream(tools=[{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object"},
+            },
+        }])
+
+        content = ""
+        name = None
+        arguments = ""
+        index = None
+
+        for event in events[:-1]:
+            for choice in event.get("choices", []):
+                delta = choice.get("delta", {})
+
+                content += delta.get("content", "")
+
+                for call in delta.get("tool_calls", []):
+                    index = call.get("index", index)
+
+                    fn = call.get("function", {})
+
+                    if fn.get("name"):
+                        name = fn["name"]
+
+                    arguments += fn.get("arguments", "")
+
+        self.assertEqual(
+            content,
+            "I'll check the weather.",
+        )
+        self.assertEqual(index, 0)
+        self.assertEqual(name, "get_weather")
+        self.assertEqual(
+            json.loads(arguments),
+            {"city": "Paris"},
+        )
+
+        reasons = [
+            choice["finish_reason"]
+            for event in events[:-1]
+            if isinstance(event, dict)
+            for choice in event.get("choices", [])
+            if choice.get("finish_reason")
+        ]
+
+        self.assertEqual(reasons, ["tool_calls"])
+        self.assertEqual(events[-1], "[DONE]")

--- a/tools/verify_container.py
+++ b/tools/verify_container.py
@@ -109,8 +109,27 @@ def main():
         bank = open(os.path.join(args.container, meta["file"]), "rb").read()
         assert len(bank) == meta["bytes"]
         shapes = []
-        for _kind, tag in KINDS:
-            t = sr.tensor(f"{prefix}model.layers.{L}.block_sparse_moe.experts.0.{tag}.weight")
+
+        deepseek_probe = (
+            f"{prefix}model.layers.{L}.mlp.experts.0.gate_proj.weight"
+        )
+        use_deepseek_names = sr.have(deepseek_probe)
+
+        if use_deepseek_names:
+            src_kinds = (
+                ("gate", "gate_proj"),
+                ("up", "up_proj"),
+                ("down", "down_proj"),
+            )
+            moe_segment = "mlp"
+        else:
+            src_kinds = KINDS
+            moe_segment = "block_sparse_moe"
+
+        for _kind, tag in src_kinds:
+            t = sr.tensor(
+                f"{prefix}model.layers.{L}.{moe_segment}.experts.0.{tag}.weight"
+            )
             shapes.append(tuple(t.shape))
 
         off, checked = 0, 0
@@ -119,8 +138,10 @@ def main():
                                            meta["codebook_base"], stages, shapes,
                                            man["expert_quant"].get("index_block", 0))
             assert off % ALIGN == 0, f"record {eid} not 4 KiB aligned"
-            for i, (kind, tag) in enumerate(KINDS):
-                W = sr.tensor(f"{prefix}model.layers.{L}.block_sparse_moe.experts.{eid}.{tag}.weight")
+            for i, (kind, tag) in enumerate(src_kinds):
+                W = sr.tensor(
+                    f"{prefix}model.layers.{L}.{moe_segment}.experts.{eid}.{tag}.weight"
+                )
                 err = (W - rec[kind]).norm() / W.norm()
                 flag = "ok " if err < 0.30 else "BAD"
                 if err >= 0.30:


### PR DESCRIPTION
## Summary

Add native Kimi K2 tool-calling support for models served through
`chat.json`.

Kimi K2 tokenizers can carry native tool-call control tokens even when
`chat.json` itself only describes ordinary conversation turns. This change
discovers those tokens when available and uses them to support
OpenAI-compatible tool declarations, assistant tool calls, tool-result
continuations, and streaming tool-call responses.

## Changes

- discover Kimi K2 native tool markers from the tokenizer
- render tool declarations in Kimi K2's native format
- render assistant tool-call and tool-result conversation turns
- parse generated Kimi K2 tool calls into OpenAI-compatible `tool_calls`
- support streaming tool-call deltas
- return `finish_reason: "tool_calls"` when appropriate
- preserve tool refusal for `chat.json` containers without the required
  native tool markers
- report `conversation + native tools` at server startup when the
  capability is detected
- support DeepSeek expert names in the container verifier

## Validation

- full test suite: 228 tests passed, 2 skipped
- `git diff --check` clean
- tested against the real Kimi K2 WASTE container
- verified non-streaming native tool-call generation
- verified OpenAI-compatible `tool_calls`
- verified `finish_reason: "tool_calls"`
- verified tool-result continuation to a final assistant response

Example live response:

```json
{
  "message": {
    "role": "assistant",
    "content": "I'll check the weather for Paris for you.",
    "tool_calls": [
      {
        "id": "call_0",
        "type": "function",
        "function": {
          "name": "get_weather",
          "arguments": "{\"city\": \"Paris\"}"
        }
      }
    ]
  },
  "finish_reason": "tool_calls"
}