### PR TITLE
model: enforce shard size at open (round-robin layout)

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -2014,9 +2014,30 @@ int waste_model_load(waste_model *m, const char *dir, int kv_cap,
                 /* Experts round-robin, so shard s holds ids s, s+N, s+2N ...
                  * and that is ceil((n_experts - s) / N) records.
                  *
+                 * Two things can be wrong with a shard, and they need
+                 * different instruments. The size is the whole-file claim:
+                 * a stale or mismatched split leaves a short shard, whose
+                 * reader would serve a neighbor record's bytes as the expert
+                 * asked for, or a long one, which hides the same confusion
+                 * one record over. The manifest bound the offsets already;
+                 * this bounds them against the file. */
+                const int recs = (m->bank[L].n_experts - s + n_sh - 1) / n_sh;
+                if (n_sh > 1 && recs > 0) {
+                    const int64_t want_bytes =
+                        (int64_t)recs * m->bank[L].rec_bytes;
+                    const int64_t have_bytes = waste_file_size(sfd);
+                    if (have_bytes < 0 || have_bytes != want_bytes) {
+                        close(sfd);
+                        js_free(&d); free(src); return -1;
+                    }
+                }
+                /* The probe is the other half: a file can be exactly the
+                 * right length and still not be readable the way the engine
+                 * will read it.
+                 *
                  * waste_dio_alloc, not a stack array. O_DIRECT rejects every
                  * transfer whose *buffer* is unaligned, not only its offset
-                 * and length — the rule bank_probe below is written for, and
+                 * and length -- the rule bank_probe below is written for, and
                  * the reason it allocates rather than declaring. A stack
                  * buffer here passed on macOS, whose F_NOCACHE has no buffer
                  * requirement, and on the x86_64 CI runner, whose filesystem
@@ -2029,7 +2050,6 @@ int waste_model_load(waste_model *m, const char *dir, int kv_cap,
                  * Skipped unless a record is a whole number of blocks, since
                  * then the offset itself is one O_DIRECT would refuse, and a
                  * refusal the device made is not evidence about the shard. */
-                const int recs = (m->bank[L].n_experts - s + n_sh - 1) / n_sh;
                 if (recs > 0 && m->bank[L].rec_bytes >= (int64_t)WASTE_ALIGN &&
                     m->bank[L].rec_bytes % (int64_t)WASTE_ALIGN == 0) {
                     void *probe = waste_dio_alloc(WASTE_ALIGN);


### PR DESCRIPTION
Companion to #53. A shard's size was never checked at open: `bank_open` validates
the record geometry, but nothing bound the file against the layout `split_banks.py`
writes. Under round-robin placement (`bank_fetch`: shard = e % n_sh) a short shard
lets the reader serve a neighbor record's bytes as the expert asked for, and a long
one hides the same confusion one record over. Both cases previously returned rc=0
with correct-looking output on untouched experts.

Found by negative control while re-verifying parity on 0.7.0, not by a failing test.

This rebases onto `f8833c8`, which added the O_DIRECT probe read at the same site.
The two checks are complementary and both are kept:

- **size** is the whole-file claim — catches short *and* long shards, and needs no
  read, so it also covers containers whose record size is not a whole number of
  blocks (where the probe deliberately skips).
- **probe** is the readability claim — a file can be exactly the right length and
  still not be readable the way the engine will read it.

Neither subsumes the other, so the size check runs first and the probe is unchanged
in behavior. `recs` is now computed once and shared: the
`ceil((n_experts - s) / n_sh)` form from the probe is equivalent to the
`floor(n/k) + (s < n%k)` form the original commit used, so this is a
simplification, not a semantic change. The size check is gated on `n_sh > 1`
because a single unsharded bank is bounded by the manifest already.

Gate: `make` clean (no new warnings) and `tests/run.sh` = **55 passed, 0 failed,
13 skipped** on macOS arm64. The skips are all missing-asset (K3 container,
tokenizer, vision source), unchanged from main.
